### PR TITLE
fix(docs): repair docs deploy + add docs build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,71 @@ jobs:
 
       - name: Run Native tests
         run: ./mill krueger.core.native.test
+
+  build-docs:
+    name: Build Docs Site (Scaladoc + playgrounds + Astro)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            docs/package-lock.json
+            sites/try-wasm/package-lock.json
+
+      - name: Cache Coursier
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/coursier
+          key: ${{ runner.os }}-coursier-${{ hashFiles('build.mill.yaml', 'krueger/**/package.mill', 'krueger/**/package.mill.yaml', 'docs/package.mill', 'mill-build/**') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-
+
+      - name: Cache Mill out
+        uses: actions/cache@v4
+        with:
+          path: out
+          key: ${{ runner.os }}-mill-docs-${{ hashFiles('build.mill.yaml', 'krueger/**/package.mill', 'krueger/**/package.mill.yaml', 'docs/package.mill', 'mill-build/**', 'VERSION') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-docs-
+
+      - name: Build full site (Scaladoc, playgrounds, Astro, try-wasm stitch)
+        run: ./mill docs.site
+
+      - name: Verify docs.site outputs
+        run: |
+          set -euo pipefail
+          missing=0
+          for path in \
+            docs/dist/index.html \
+            docs/dist/api/index.html \
+            docs/dist/api/jvm/index.html \
+            docs/dist/api/js/index.html \
+            docs/dist/api/native/index.html \
+            docs/dist/try-wasm/index.html \
+            docs/src/playground/generated/app/main.js \
+            sites/try-wasm/static/wasm/facade \
+            sites/try-wasm/static/wasm/webgc; do
+            if [ ! -e "$path" ]; then
+              echo "MISSING: $path"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: Upload docs/dist as build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-dist
+          path: docs/dist
+          retention-days: 7
+          if-no-files-found: error

--- a/docs/package.mill
+++ b/docs/package.mill
@@ -251,6 +251,64 @@ object `package` extends Module {
     os.proc("npm", "run", "build").call(cwd = tryWasmDir, stdout = os.Inherit, stderr = os.Inherit)
   }
 
+  /** Copy the Scala.js link output from `linkDir` into
+    * `docs/src/playground/generated/app/` so Vite can bundle it during
+    * `astro build`. Mirrors `krueger.webapp.writeToDocsSrc`, but inlined here
+    * because Mill 1.x does not allow invoking `Task.Command`s from inside
+    * another task body (the body silently does not execute). The enclosing
+    * `docs.site` / `docs.prepareLocalDevSite` are themselves Commands so they
+    * are permitted to write outside `Task.dest`.
+    */
+  private def copyWebappBundleToDocsSrc(linkDir: os.Path, logInfo: String => Unit): Unit = {
+    val target = repoRoot / "docs" / "src" / "playground" / "generated" / "app"
+    if (os.exists(target)) os.remove.all(target)
+    os.makeDir.all(target)
+    var copied = 0
+    for (child <- os.list(linkDir)) {
+      os.copy.into(child, target, replaceExisting = true)
+      copied += 1
+    }
+    logInfo(s"docs: copied $copied Laminar bundle files from $linkDir -> $target")
+  }
+
+  /** Copy the webapp-wasm facade + compiler-api wasm link outputs into
+    * `sites/try-wasm/static/wasm/{facade,webgc}/`. Mirrors
+    * `krueger.webapp-wasm.writeToWasmSite`, inlined for the same reason as
+    * `copyWebappBundleToDocsSrc`. Strips `//# sourceMappingURL=` references
+    * from copied `.js` files (the corresponding `.map` files are skipped).
+    */
+  private def copyWasmArtifactsToTryWasm(
+      facadeDir: os.Path,
+      webgcDir: os.Path,
+      logInfo: String => Unit
+  ): Unit = {
+    val target = repoRoot / "sites" / "try-wasm" / "static" / "wasm"
+    if (os.exists(target)) os.remove.all(target)
+    os.makeDir.all(target / "facade")
+    os.makeDir.all(target / "webgc")
+    os.write.over(target / ".gitkeep", "")
+
+    def stripSourceMapReference(source: String): String =
+      source.linesIterator.filterNot(_.startsWith("//# sourceMappingURL=")).mkString("\n") + "\n"
+
+    def copyChildren(from: os.Path, to: os.Path): Int = {
+      var copied = 0
+      for (child <- os.list(from) if !child.last.endsWith(".map")) {
+        val out = to / child.last
+        if (child.last.endsWith(".js")) os.write.over(out, stripSourceMapReference(os.read(child)))
+        else os.copy.over(child, out)
+        copied += 1
+      }
+      copied
+    }
+
+    val facadeCount = copyChildren(facadeDir, target / "facade")
+    val webgcCount  = copyChildren(webgcDir, target / "webgc")
+    logInfo(
+      s"docs: copied facade=$facadeCount from $facadeDir and webgc=$webgcCount from $webgcDir -> $target"
+    )
+  }
+
   /** Copy `sites/try-wasm/build/` into `destRoot` (wiping `destRoot` first). */
   private def copyTryWasmBuildInto(destRoot: os.Path, logInfo: String => Unit): Unit = {
     val buildDir = repoRoot / "sites" / "try-wasm" / "build"
@@ -284,10 +342,14 @@ object `package` extends Module {
     )
 
     Task.log.info("docs.prepareLocalDevSite: writing Laminar playground bundle")
-    build.krueger.webapp.writeToDocsSrc()
+    copyWebappBundleToDocsSrc(build.krueger.webapp.fullLinkJS().dest.path, Task.log.info(_))
 
     Task.log.info("docs.prepareLocalDevSite: writing webapp-wasm compiler artifacts")
-    build.krueger.`webapp-wasm`.writeToWasmSite()
+    copyWasmArtifactsToTryWasm(
+      facadeDir = build.krueger.`webapp-wasm`.fullLinkJS().dest.path,
+      webgcDir  = build.krueger.`compiler-api`.wasm.fullLinkJS().dest.path,
+      logInfo   = Task.log.info(_)
+    )
 
     runTryWasmNpmBuild(Task.log.info(_))
 
@@ -336,10 +398,14 @@ object `package` extends Module {
     )
 
     Task.log.info("docs.site: writing Laminar playground bundle")
-    build.krueger.webapp.writeToDocsSrc()
+    copyWebappBundleToDocsSrc(build.krueger.webapp.fullLinkJS().dest.path, Task.log.info(_))
 
     Task.log.info("docs.site: writing webapp-wasm compiler artifacts")
-    build.krueger.`webapp-wasm`.writeToWasmSite()
+    copyWasmArtifactsToTryWasm(
+      facadeDir = build.krueger.`webapp-wasm`.fullLinkJS().dest.path,
+      webgcDir  = build.krueger.`compiler-api`.wasm.fullLinkJS().dest.path,
+      logInfo   = Task.log.info(_)
+    )
 
     runTryWasmNpmBuild(Task.log.info(_))
 


### PR DESCRIPTION
## Summary
- Inline the side-effecting copy work from `krueger.webapp.writeToDocsSrc` and `krueger.webapp-wasm.writeToWasmSite` into `docs.site` / `docs.prepareLocalDevSite`. Mill 1.x silently does not execute a `Task.Command`'s body when it is invoked from inside another task — the previous code expected those commands to materialise `docs/src/playground/generated/app/main.js` and `sites/try-wasm/static/wasm/{facade,webgc}/`, but the bodies never ran, so `astro build` failed every Pages deploy with `Could not resolve "./generated/app/main.js"`.
- Add a `build-docs` job to `.github/workflows/ci.yml` that runs `./mill docs.site`, asserts the expected outputs are present, and uploads `docs/dist` as an artifact. This catches the same class of regression on PRs before it merges.

## Why not just convert the Commands to Tasks?
Tried; rejected by Mill 1.x. Regular `Task`s are sandboxed and may only write under `Task.dest`. The two helpers must write to fixed paths under `docs/src/...` and `sites/try-wasm/static/...`, which only `Task.Command`s are permitted to do. Inlining into the existing `docs.site` Command (already permitted to write outside `Task.dest`) is the smallest correct change.

## Test plan
- [x] Local: `./mill docs.site` succeeds and produces `docs/dist/` with Scaladoc trees, Astro pages, `try-wasm/`, plus the generated Laminar bundle under `docs/src/playground/generated/app/main.js` and WASM artifacts under `sites/try-wasm/static/wasm/{facade,webgc}/`.
- [ ] CI `build-docs` job passes on this PR (this is the new gate that would have caught the regression).
- [ ] After merge, `Deploy Docs` workflow on `main` succeeds.