### PR TITLE
feat(diagnostics): structured ParseDiagnostic with stable codes (E-6.5)

### DIFF
--- a/docs/scripts/check-webapp-wasm-browser.mjs
+++ b/docs/scripts/check-webapp-wasm-browser.mjs
@@ -75,6 +75,7 @@ try {
                 malformedErrorCount: malformed.errors.length,
                 malformedPhase: malformed.errors[0]?.phase,
                 malformedMessage: malformed.errors[0]?.message,
+                malformedContextLineCount: malformed.errors[0]?.contextLines?.length ?? 0,
                 deterministic: String(valid.value) === String(again.value),
             };
         });
@@ -82,8 +83,11 @@ try {
         if (!result.validOk || !result.validValue.includes('CstModule(')) fail(`valid parseCst failed: ${JSON.stringify(result)}`);
         if (!result.malformedOk || result.malformedErrorCount < 1) fail(`malformed parseCst did not return errors: ${JSON.stringify(result)}`);
         if (result.malformedPhase !== 'cst') fail(`malformed parseCst phase mismatch: ${JSON.stringify(result)}`);
-        if (!String(result.malformedMessage).includes('unexpected end of input')) {
+        if (!String(result.malformedMessage).includes('I ran into the end of the file unexpectedly.')) {
             fail(`malformed parseCst message mismatch: ${JSON.stringify(result)}`);
+        }
+        if (!result.malformedContextLineCount || result.malformedContextLineCount < 1) {
+            fail(`malformed parseCst missing contextLines: ${JSON.stringify(result)}`);
         }
         if (!result.deterministic) fail(`repeated parseCst was not deterministic: ${JSON.stringify(result)}`);
     } finally {

--- a/docs/src/content/docs/tooling.md
+++ b/docs/src/content/docs/tooling.md
@@ -58,7 +58,8 @@ Most calls return a plain **envelope** object:
     expected?: string[],  // parser-expected tokens at failure site
     suggestion?: string,  // optional human hint for common mistakes
     line?: number,
-    column?: number
+    column?: number,
+    contextLines?: [{ line: number, text: string, isErrorLine: boolean }, ...]
   }, ...]
 }
 ```

--- a/docs/src/content/docs/tooling.md
+++ b/docs/src/content/docs/tooling.md
@@ -50,7 +50,16 @@ Most calls return a plain **envelope** object:
   ok: boolean,
   value: /* opaque handle, matches, or tokens — depends on API */,
   logs: string[],
-  errors: [{ phase, message, span? }, ...]
+  errors: [{
+    phase,
+    message,
+    span?: { start, end },
+    code?: string,        // stable diagnostic code, e.g. ELM-P001
+    expected?: string[],  // parser-expected tokens at failure site
+    suggestion?: string,  // optional human hint for common mistakes
+    line?: number,
+    column?: number
+  }, ...]
 }
 ```
 

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/CompilerComponent.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/CompilerComponent.scala
@@ -10,8 +10,8 @@ import io.eleven19.krueger.trees.query.QueryLogic
   *
   * All effectful operations return a Kyo-backed [[QueryLogic.QueryEffect]] so consumers can compose the compiler
   * alongside their own stateful effects and run everything at the edge of a UI or FFI boundary, receiving a plain
-  * [[QueryLogic.Result]] envelope (context, logs, errors, value). The effect type itself never crosses the JS /
-  * WASM FFI boundary.
+  * [[QueryLogic.Result]] envelope (context, logs, errors, value). The effect type itself never crosses the JS / WASM
+  * FFI boundary.
   *
   * @tparam Ctx
   *   the caller-chosen context type threaded through the compile effect. Use `Unit` when no context is needed.

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/Krueger.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/Krueger.scala
@@ -27,17 +27,17 @@ object Krueger:
         def parseCst(source: String): CompileEff[Ctx, CstModule] =
             CoreKrueger.parseCst(source) match
                 case parsley.Success(m) => m
-                case parsley.Failure(msg) =>
+                case parsley.Failure(diagnostic) =>
                     QueryLogic.failFast[Ctx, String, CompileError](
-                        CompileError.ParseError(phase = "cst", message = msg.toString)
+                        CompileError.ParseError(phase = "cst", diagnostic = diagnostic)
                     )
 
         def parseAst(source: String): CompileEff[Ctx, AstModule] =
             CoreKrueger.parseAst(source) match
                 case parsley.Success(m) => m
-                case parsley.Failure(msg) =>
+                case parsley.Failure(diagnostic) =>
                     QueryLogic.failFast[Ctx, String, CompileError](
-                        CompileError.ParseError(phase = "ast", message = msg.toString)
+                        CompileError.ParseError(phase = "ast", diagnostic = diagnostic)
                     )
 
         def parseQuery(q: String): CompileEff[Ctx, Query] =

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/Krueger.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/Krueger.scala
@@ -27,7 +27,7 @@ object Krueger:
         def parseCst(source: String): CompileEff[Ctx, CstModule] =
             CoreKrueger.parseCst(source) match
                 case parsley.Success(m) => m
-                case parsley.Failure(diagnostic) =>
+                case parsley.Failure(diagnostic: ParseDiagnostic) =>
                     QueryLogic.failFast[Ctx, String, CompileError](
                         CompileError.ParseError(phase = "cst", diagnostic = diagnostic)
                     )
@@ -35,7 +35,7 @@ object Krueger:
         def parseAst(source: String): CompileEff[Ctx, AstModule] =
             CoreKrueger.parseAst(source) match
                 case parsley.Success(m) => m
-                case parsley.Failure(diagnostic) =>
+                case parsley.Failure(diagnostic: ParseDiagnostic) =>
                     QueryLogic.failFast[Ctx, String, CompileError](
                         CompileError.ParseError(phase = "ast", diagnostic = diagnostic)
                     )

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
@@ -3,6 +3,7 @@ package io.eleven19.krueger.compiler.abi
 import io.eleven19.krueger.compiler.CompileError
 import io.eleven19.krueger.compiler.CompilerComponent
 import io.eleven19.krueger.compiler.DiagnosticContextLine
+import io.eleven19.krueger.compiler.DiagnosticCode
 import io.eleven19.krueger.compiler.Span
 
 final case class InvokeSpan(start: Int, end: Int) derives CanEqual
@@ -48,7 +49,7 @@ object InvokeError:
                     phase = phase,
                     message = diagnostic.message,
                     span = Some(InvokeSpan.fromCompilerSpan(diagnostic.toCompilerSpan)),
-                    code = Some(diagnostic.code),
+                    code = Some(DiagnosticCode.unwrap(diagnostic.code)),
                     expected = diagnostic.expected,
                     suggestion = diagnostic.suggestion,
                     line = Some(diagnostic.span.line),

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
@@ -14,18 +14,28 @@ object InvokeSpan:
 final case class InvokeError(
     phase: String,
     message: String,
-    span: Option[InvokeSpan] = None
+    span: Option[InvokeSpan] = None,
+    code: Option[String] = None,
+    expected: List[String] = Nil,
+    suggestion: Option[String] = None,
+    line: Option[Int] = None,
+    column: Option[Int] = None
 ) derives CanEqual
 
 object InvokeError:
 
     def fromCompileError(error: CompileError): InvokeError =
         error match
-            case CompileError.ParseError(phase, message, span) =>
+            case CompileError.ParseError(phase, diagnostic) =>
                 InvokeError(
                     phase = phase,
-                    message = message,
-                    span = span.map(InvokeSpan.fromCompilerSpan)
+                    message = diagnostic.message,
+                    span = Some(InvokeSpan.fromCompilerSpan(diagnostic.toCompilerSpan)),
+                    code = Some(diagnostic.code),
+                    expected = diagnostic.expected,
+                    suggestion = diagnostic.suggestion,
+                    line = Some(diagnostic.span.line),
+                    column = Some(diagnostic.span.column)
                 )
             case CompileError.QueryError(message, span) =>
                 InvokeError(

--- a/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
+++ b/krueger/compiler-api/src/io/eleven19/krueger/compiler/abi/InvokeResponse.scala
@@ -2,6 +2,7 @@ package io.eleven19.krueger.compiler.abi
 
 import io.eleven19.krueger.compiler.CompileError
 import io.eleven19.krueger.compiler.CompilerComponent
+import io.eleven19.krueger.compiler.DiagnosticContextLine
 import io.eleven19.krueger.compiler.Span
 
 final case class InvokeSpan(start: Int, end: Int) derives CanEqual
@@ -11,6 +12,21 @@ object InvokeSpan:
     def fromCompilerSpan(span: Span): InvokeSpan =
         InvokeSpan(start = span.start, end = span.end)
 
+final case class InvokeContextLine(
+    line: Int,
+    text: String,
+    isErrorLine: Boolean
+) derives CanEqual
+
+object InvokeContextLine:
+
+    def fromDiagnosticContextLine(line: DiagnosticContextLine): InvokeContextLine =
+        InvokeContextLine(
+            line = line.line,
+            text = line.text,
+            isErrorLine = line.isErrorLine
+        )
+
 final case class InvokeError(
     phase: String,
     message: String,
@@ -19,7 +35,8 @@ final case class InvokeError(
     expected: List[String] = Nil,
     suggestion: Option[String] = None,
     line: Option[Int] = None,
-    column: Option[Int] = None
+    column: Option[Int] = None,
+    contextLines: List[InvokeContextLine] = Nil
 ) derives CanEqual
 
 object InvokeError:
@@ -35,7 +52,8 @@ object InvokeError:
                     expected = diagnostic.expected,
                     suggestion = diagnostic.suggestion,
                     line = Some(diagnostic.span.line),
-                    column = Some(diagnostic.span.column)
+                    column = Some(diagnostic.span.column),
+                    contextLines = diagnostic.contextLines.map(InvokeContextLine.fromDiagnosticContextLine)
                 )
             case CompileError.QueryError(message, span) =>
                 InvokeError(

--- a/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/CompilerComponentSpec.scala
+++ b/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/CompilerComponentSpec.scala
@@ -2,6 +2,7 @@ package io.eleven19.krueger.compiler
 
 import zio.test.*
 
+import io.eleven19.krueger.Krueger as CoreKrueger
 import io.eleven19.krueger.cst.CstNode
 import io.eleven19.krueger.cst.CstQueryableTree.given
 
@@ -28,6 +29,11 @@ object CompilerComponentSpec extends ZIOSpecDefault:
             case Right(value) => value
             case Left(_)      => throw new AssertionError(clue)
 
+    private def expectedParseError(phase: String, source: String): CompileError.ParseError =
+        CoreKrueger.parseCst(source) match
+            case parsley.Failure(diagnostic) => CompileError.ParseError(phase = phase, diagnostic = diagnostic)
+            case parsley.Success(_)            => throw new AssertionError(s"expected parse failure for: $source")
+
     private val compiler: CompilerComponent[Unit] = Krueger.compiler[Unit]
 
     private val simpleSource =
@@ -41,25 +47,6 @@ object CompilerComponentSpec extends ZIOSpecDefault:
     private val simpleQuery    = "(CstValueDeclaration) @v"
     private val malformedQuery = "(unbalanced"
     private val zeroMatchQuery = "(nonexistent_node_type) @x"
-
-    private val expectedMalformedSourceMessage =
-        List(
-            "(line 3, column 4):",
-            "  unexpected end of input",
-            "  expected \"\"\", \"'\", \"+\", \"-\", -, ., \\, case, digit, identifier, if, let, open brace, open parenthesis, or open square bracket",
-            "  >",
-            "  >x =",
-            "      ^"
-        ).mkString("\n")
-
-    private val expectedEmptySourceMessage =
-        List(
-            "(line 1, column 1):",
-            "  unexpected end of input",
-            "  expected effect, module, or port",
-            "  >",
-            "   ^"
-        ).mkString("\n")
 
     private val expectedEmptyQueryMessage =
         List(
@@ -102,10 +89,7 @@ object CompilerComponentSpec extends ZIOSpecDefault:
             },
             test("negative path: malformed source produces the expected ParseError envelope") {
                 val actual = snapshot(run(compiler.parseCst(malformedSource)))
-                val expectedError = CompileError.ParseError(
-                    phase = "cst",
-                    message = expectedMalformedSourceMessage
-                )
+                val expectedError = expectedParseError(phase = "cst", source = malformedSource)
                 val expected = Snapshot(
                     logs = Vector.empty,
                     errors = Vector(expectedError),
@@ -129,10 +113,7 @@ object CompilerComponentSpec extends ZIOSpecDefault:
             },
             test("edge path: empty source returns the expected ParseError envelope") {
                 val actual = snapshot(run(compiler.parseCst("")))
-                val expectedError = CompileError.ParseError(
-                    phase = "cst",
-                    message = expectedEmptySourceMessage
-                )
+                val expectedError = expectedParseError(phase = "cst", source = "")
                 val expected = Snapshot(
                     logs = Vector.empty,
                     errors = Vector(expectedError),

--- a/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/CompilerComponentSpec.scala
+++ b/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/CompilerComponentSpec.scala
@@ -31,7 +31,8 @@ object CompilerComponentSpec extends ZIOSpecDefault:
 
     private def expectedParseError(phase: String, source: String): CompileError.ParseError =
         CoreKrueger.parseCst(source) match
-            case parsley.Failure(diagnostic) => CompileError.ParseError(phase = phase, diagnostic = diagnostic)
+            case parsley.Failure(diagnostic: ParseDiagnostic) =>
+                CompileError.ParseError(phase = phase, diagnostic = diagnostic)
             case parsley.Success(_)            => throw new AssertionError(s"expected parse failure for: $source")
 
     private val compiler: CompilerComponent[Unit] = Krueger.compiler[Unit]

--- a/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
+++ b/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
@@ -2,6 +2,9 @@ package io.eleven19.krueger.compiler.abi
 
 import zio.test.*
 
+import io.eleven19.krueger.Krueger as CoreKrueger
+import io.eleven19.krueger.compiler.CompileError
+
 import InvokeJson.decode
 import InvokeJson.given
 
@@ -15,15 +18,12 @@ object InvokeCompilerSpec extends ZIOSpecDefault:
 
     private val malformedSource = "module Demo exposing (..)\n\nmain ="
 
-    private val expectedMalformedSourceMessage =
-        List(
-            "(line 3, column 7):",
-            "  unexpected end of input",
-            "  expected \"\"\", \"'\", \"+\", \"-\", -, ., \\, case, digit, identifier, if, let, open brace, open parenthesis, or open square bracket",
-            "  >",
-            "  >main =",
-            "         ^"
-        ).mkString("\n")
+    private def expectedParseInvokeError(source: String): InvokeError =
+        CoreKrueger.parseCst(source) match
+            case parsley.Failure(diagnostic) =>
+                InvokeError.fromCompileError(CompileError.ParseError(phase = "cst", diagnostic = diagnostic))
+            case parsley.Success(_) =>
+                throw new AssertionError(s"expected parse failure for: $source")
 
     private def invoke(op: String, source: String): InvokeResponse =
         decode[InvokeResponse](InvokeCompiler.invoke(op, source))
@@ -46,13 +46,7 @@ object InvokeCompilerSpec extends ZIOSpecDefault:
                 !response.ok,
                 response.value.isEmpty,
                 response.logs.isEmpty,
-                response.errors == Vector(
-                    InvokeError(
-                        phase = "cst",
-                        message = expectedMalformedSourceMessage,
-                        span = None
-                    )
-                )
+                response.errors == Vector(expectedParseInvokeError(malformedSource))
             )
         },
         test("edge path: unknown operation returns a structured internal error envelope") {

--- a/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
+++ b/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
@@ -42,12 +42,15 @@ object InvokeCompilerSpec extends ZIOSpecDefault:
         },
         test("failure path: malformed source returns a structured parse error envelope") {
             val response = invoke("parseCst", s"""{"source":${stringLiteral(malformedSource)}}""")
+            val expected   = expectedParseInvokeError(malformedSource)
 
             assertTrue(
                 !response.ok,
                 response.value.isEmpty,
                 response.logs.isEmpty,
-                response.errors == Vector(expectedParseInvokeError(malformedSource))
+                response.errors == Vector(expected),
+                response.errors.head.contextLines.nonEmpty,
+                response.errors.head.contextLines.count(_.isErrorLine) == 1
             )
         },
         test("edge path: unknown operation returns a structured internal error envelope") {

--- a/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
+++ b/krueger/compiler-api/test/src/io/eleven19/krueger/compiler/abi/InvokeCompilerSpec.scala
@@ -4,6 +4,7 @@ import zio.test.*
 
 import io.eleven19.krueger.Krueger as CoreKrueger
 import io.eleven19.krueger.compiler.CompileError
+import io.eleven19.krueger.compiler.ParseDiagnostic
 
 import InvokeJson.decode
 import InvokeJson.given
@@ -20,7 +21,7 @@ object InvokeCompilerSpec extends ZIOSpecDefault:
 
     private def expectedParseInvokeError(source: String): InvokeError =
         CoreKrueger.parseCst(source) match
-            case parsley.Failure(diagnostic) =>
+            case parsley.Failure(diagnostic: ParseDiagnostic) =>
                 InvokeError.fromCompileError(CompileError.ParseError(phase = "cst", diagnostic = diagnostic))
             case parsley.Success(_) =>
                 throw new AssertionError(s"expected parse failure for: $source")

--- a/krueger/core/package.mill
+++ b/krueger/core/package.mill
@@ -12,7 +12,8 @@ trait CoreModule extends _root_.build.CommonScalaModule
         mvn"com.github.j-mie6::parsley::4.6.2",
         mvn"io.getkyo::kyo-prelude::${_root_.build.KruegerVersions.Kyo}",
         mvn"io.getkyo::kyo-core::${_root_.build.KruegerVersions.Kyo}",
-        mvn"com.outr::scribe::${_root_.build.KruegerVersions.Scribe}"
+        mvn"com.outr::scribe::${_root_.build.KruegerVersions.Scribe}",
+        mvn"io.github.kitlangton::neotype::0.4.10"
     )
 }
 

--- a/krueger/core/src/io/eleven19/krueger/Krueger.scala
+++ b/krueger/core/src/io/eleven19/krueger/Krueger.scala
@@ -1,15 +1,23 @@
 package io.eleven19.krueger
 
+import io.eleven19.krueger.compiler.ParseDiagnostic
 import io.eleven19.krueger.cst.{CstModule, CstTrivia}
 import io.eleven19.krueger.ast.Module
-import io.eleven19.krueger.parser.{CommentScanner, CstLowering, ModuleParser, TriviaAssociator}
+import io.eleven19.krueger.parser.{
+    CommentScanner,
+    CstLowering,
+    ModuleParser,
+    ParseDiagnosticErrorBuilder,
+    TriviaAssociator
+}
 
 /** Public API entry point for the Krueger Elm dialect parser. */
 object Krueger:
 
     /** Parse Elm source code into a CST. */
-    def parseCst(source: String): parsley.Result[String, CstModule] =
-        ModuleParser.module.parse(source).map { module =>
+    def parseCst(source: String): parsley.Result[ParseDiagnostic, CstModule] =
+        val errorBuilder = ParseDiagnosticErrorBuilder(source)
+        ModuleParser.module.parse[ParseDiagnostic](source)(using errorBuilder).map { module =>
             val withComments = CstModule(
                 module.moduleDecl,
                 module.imports,
@@ -20,5 +28,5 @@ object Krueger:
         }
 
     /** Parse Elm source code into an AST (CST lowered). */
-    def parseAst(source: String): parsley.Result[String, Module] =
+    def parseAst(source: String): parsley.Result[ParseDiagnostic, Module] =
         parseCst(source).map(CstLowering.lowerModule)

--- a/krueger/core/src/io/eleven19/krueger/compiler/CompileError.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/CompileError.scala
@@ -16,7 +16,7 @@ object CompileError:
 
         def span: Option[Span] = Some(diagnostic.toCompilerSpan)
 
-        def code: String = diagnostic.code
+        def code: DiagnosticCode = diagnostic.code
 
         def expected: List[String] = diagnostic.expected
 

--- a/krueger/core/src/io/eleven19/krueger/compiler/CompileError.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/CompileError.scala
@@ -2,7 +2,7 @@ package io.eleven19.krueger.compiler
 
 /** Structured compilation diagnostics emitted by Krueger compiler and tooling APIs.
   *
-  * Cases carry enough context (phase, message, optional span) so downstream UIs can render actionable errors without
+  * Cases carry enough context (phase, diagnostic payload) so downstream UIs can render actionable errors without
   * re-parsing messages.
   */
 sealed trait CompileError derives CanEqual:
@@ -11,7 +11,16 @@ sealed trait CompileError derives CanEqual:
 object CompileError:
 
     /** Failure while parsing Elm source into a CST or AST. */
-    final case class ParseError(phase: String, message: String, span: Option[Span] = None) extends CompileError
+    final case class ParseError(phase: String, diagnostic: ParseDiagnostic) extends CompileError:
+        def message: String = diagnostic.message
+
+        def span: Option[Span] = Some(diagnostic.toCompilerSpan)
+
+        def code: String = diagnostic.code
+
+        def expected: List[String] = diagnostic.expected
+
+        def suggestion: Option[String] = diagnostic.suggestion
 
     /** Failure while parsing or evaluating a query. */
     final case class QueryError(message: String, span: Option[Span] = None) extends CompileError

--- a/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticCode.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticCode.scala
@@ -1,0 +1,28 @@
+package io.eleven19.krueger.compiler
+
+import neotype.*
+
+/** Stable alphanumeric code assigned to a parse or tokenizer diagnostic. */
+type DiagnosticCode = DiagnosticCode.Type
+
+object DiagnosticCode extends Newtype[String]:
+
+    private val Pattern = raw"ELM-[PT]\d{3}".r
+
+    override inline def validate(input: String): Boolean | String =
+        if Pattern.matches(input) then true
+        else s"DiagnosticCode must match ELM-P### or ELM-T###, got: $input"
+
+    given CanEqual[Type, Type] = CanEqual.derived
+
+    val UnexpectedEndOfInput: DiagnosticCode         = unsafeMake("ELM-P001")
+    val UnexpectedToken: DiagnosticCode              = unsafeMake("ELM-P002")
+    val SpecialisedParseFailure: DiagnosticCode      = unsafeMake("ELM-P003")
+    val TokenizerUnexpectedCharacter: DiagnosticCode = unsafeMake("ELM-T001")
+
+    def isTokenizer(code: DiagnosticCode): Boolean =
+        unwrap(code).startsWith("ELM-T")
+
+    def kindLabel(code: DiagnosticCode): String =
+        if isTokenizer(code) then "TOKENIZE ERROR"
+        else "PARSE ERROR"

--- a/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticContextLine.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticContextLine.scala
@@ -1,0 +1,7 @@
+package io.eleven19.krueger.compiler
+
+final case class DiagnosticContextLine(
+    line: Int,
+    text: String,
+    isErrorLine: Boolean
+) derives CanEqual

--- a/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
@@ -1,0 +1,66 @@
+package io.eleven19.krueger.compiler
+
+/** Formats structured parse diagnostics into human-friendly, Elm-inspired messages. */
+object DiagnosticMessageFormatter:
+
+    def format(
+        source: String,
+        code: String,
+        line: Int,
+        column: Int,
+        unexpected: Option[String],
+        expected: List[String],
+        reasons: Seq[String],
+        suggestion: Option[String],
+        errorWidth: Int
+    ): String =
+        val header = formatHeader(code, line, column)
+        val body =
+            List(
+                unexpectedExplanation(code, unexpected),
+                expectedExplanation(expected),
+                reasonsExplanation(reasons)
+            ).filter(_.nonEmpty).mkString("\n\n")
+        val snippet = sourceSnippet(source, line, column, errorWidth)
+        val hint    = suggestion.map(s => s"\n\nHint: $s").getOrElse("")
+        List(header, body, snippet).filter(_.nonEmpty).mkString("\n\n") + hint
+
+    private def formatHeader(code: String, line: Int, column: Int): String =
+        val kind =
+            if code.startsWith("ELM-T") then "TOKENIZE ERROR"
+            else "PARSE ERROR"
+        s"-- $kind ($code) at line $line, column $column"
+
+    private def unexpectedExplanation(code: String, unexpected: Option[String]): String =
+        unexpected match
+            case Some("end of input") =>
+                "I ran into the end of the file unexpectedly."
+            case Some(value) if code.startsWith("ELM-T") =>
+                s"I ran into an unexpected character:\n\n    $value"
+            case Some(token) =>
+                s"I ran into an unexpected token:\n\n    $token"
+            case None =>
+                "I ran into something I did not expect here."
+
+    private def expectedExplanation(expected: List[String]): String =
+        if expected.isEmpty then ""
+        else
+            val items = expected.map(item => s"    $item").mkString("\n")
+            s"I was expecting one of the following:\n\n$items"
+
+    private def reasonsExplanation(reasons: Seq[String]): String =
+        reasons.filter(_.nonEmpty) match
+            case Nil   => ""
+            case lines => lines.mkString("\n")
+
+    private def sourceSnippet(source: String, line: Int, column: Int, errorWidth: Int): String =
+        val sourceLine = lineAt(source, line)
+        val gutter     = s"$line| "
+        val caretWidth = errorWidth.max(1)
+        val caretStart = gutter.length + (column - 1).max(0)
+        val caret      = " " * caretStart + ("^" * caretWidth)
+        s"$gutter$sourceLine\n$caret"
+
+    private def lineAt(source: String, oneBasedLine: Int): String =
+        if source.isEmpty then ""
+        else source.linesIterator.toVector.lift(oneBasedLine - 1).getOrElse("")

--- a/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
@@ -10,7 +10,7 @@ object DiagnosticMessageFormatter:
 
     def format(
         source: String,
-        code: String,
+        code: DiagnosticCode,
         line: Int,
         column: Int,
         unexpected: Option[String],
@@ -38,17 +38,14 @@ object DiagnosticMessageFormatter:
             contextLines = snippet.contextLines
         )
 
-    private def formatHeader(code: String, line: Int, column: Int): String =
-        val kind =
-            if code.startsWith("ELM-T") then "TOKENIZE ERROR"
-            else "PARSE ERROR"
-        s"-- $kind ($code) at line $line, column $column"
+    private def formatHeader(code: DiagnosticCode, line: Int, column: Int): String =
+        s"-- ${DiagnosticCode.kindLabel(code)} (${DiagnosticCode.unwrap(code)}) at line $line, column $column"
 
-    private def unexpectedExplanation(code: String, unexpected: Option[String]): String =
+    private def unexpectedExplanation(code: DiagnosticCode, unexpected: Option[String]): String =
         unexpected match
             case Some("end of input") =>
                 "I ran into the end of the file unexpectedly."
-            case Some(value) if code.startsWith("ELM-T") =>
+            case Some(value) if DiagnosticCode.isTokenizer(code) =>
                 s"I ran into an unexpected character:\n\n    $value"
             case Some(token) =>
                 s"I ran into an unexpected token:\n\n    $token"

--- a/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatter.scala
@@ -3,6 +3,11 @@ package io.eleven19.krueger.compiler
 /** Formats structured parse diagnostics into human-friendly, Elm-inspired messages. */
 object DiagnosticMessageFormatter:
 
+    final case class FormattedDiagnostic(
+        message: String,
+        contextLines: List[DiagnosticContextLine]
+    ) derives CanEqual
+
     def format(
         source: String,
         code: String,
@@ -13,7 +18,7 @@ object DiagnosticMessageFormatter:
         reasons: Seq[String],
         suggestion: Option[String],
         errorWidth: Int
-    ): String =
+    ): FormattedDiagnostic =
         val header = formatHeader(code, line, column)
         val body =
             List(
@@ -21,9 +26,17 @@ object DiagnosticMessageFormatter:
                 expectedExplanation(expected),
                 reasonsExplanation(reasons)
             ).filter(_.nonEmpty).mkString("\n\n")
-        val snippet = sourceSnippet(source, line, column, errorWidth)
-        val hint    = suggestion.map(s => s"\n\nHint: $s").getOrElse("")
-        List(header, body, snippet).filter(_.nonEmpty).mkString("\n\n") + hint
+        val snippet = SourceSnippetBuilder.build(
+            source = source,
+            errorLine = line,
+            column = column,
+            errorWidth = errorWidth
+        )
+        val hint = suggestion.map(s => s"\n\nHint: $s").getOrElse("")
+        FormattedDiagnostic(
+            message = List(header, body, snippet.rendered).filter(_.nonEmpty).mkString("\n\n") + hint,
+            contextLines = snippet.contextLines
+        )
 
     private def formatHeader(code: String, line: Int, column: Int): String =
         val kind =
@@ -52,15 +65,3 @@ object DiagnosticMessageFormatter:
         reasons.filter(_.nonEmpty) match
             case Nil   => ""
             case lines => lines.mkString("\n")
-
-    private def sourceSnippet(source: String, line: Int, column: Int, errorWidth: Int): String =
-        val sourceLine = lineAt(source, line)
-        val gutter     = s"$line| "
-        val caretWidth = errorWidth.max(1)
-        val caretStart = gutter.length + (column - 1).max(0)
-        val caret      = " " * caretStart + ("^" * caretWidth)
-        s"$gutter$sourceLine\n$caret"
-
-    private def lineAt(source: String, oneBasedLine: Int): String =
-        if source.isEmpty then ""
-        else source.linesIterator.toVector.lift(oneBasedLine - 1).getOrElse("")

--- a/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
@@ -3,7 +3,7 @@ package io.eleven19.krueger.compiler
 final case class SourceSpan(start: Int, end: Int, line: Int, column: Int) derives CanEqual
 
 final case class ParseDiagnostic(
-    code: String,
+    code: DiagnosticCode,
     span: SourceSpan,
     message: String,
     expected: List[String],
@@ -19,7 +19,7 @@ object ParseDiagnostic:
         val start     = SourceOffsets.offsetAt(source, line, column)
         val formatted = DiagnosticMessageFormatter.format(
             source = source,
-            code = DiagnosticCodes.UnexpectedEndOfInput,
+            code = DiagnosticCode.UnexpectedEndOfInput,
             line = line,
             column = column,
             unexpected = Some("end of input"),
@@ -29,7 +29,7 @@ object ParseDiagnostic:
             errorWidth = 0
         )
         ParseDiagnostic(
-            code = DiagnosticCodes.UnexpectedEndOfInput,
+            code = DiagnosticCode.UnexpectedEndOfInput,
             span = SourceSpan(start = start, end = start, line = line, column = column),
             message = formatted.message,
             expected = expected,
@@ -48,7 +48,7 @@ object ParseDiagnostic:
         val end       = (start + width.max(1)).min(source.length.max(start + 1))
         val formatted = DiagnosticMessageFormatter.format(
             source = source,
-            code = DiagnosticCodes.UnexpectedToken,
+            code = DiagnosticCode.UnexpectedToken,
             line = line,
             column = column,
             unexpected = Some(unexpected),
@@ -58,7 +58,7 @@ object ParseDiagnostic:
             errorWidth = width
         )
         ParseDiagnostic(
-            code = DiagnosticCodes.UnexpectedToken,
+            code = DiagnosticCode.UnexpectedToken,
             span = SourceSpan(start = start, end = end, line = line, column = column),
             message = formatted.message,
             expected = expected,
@@ -69,7 +69,7 @@ object ParseDiagnostic:
         val (line, column) = SourceOffsets.lineColumnAt(source, offset)
         val formatted = DiagnosticMessageFormatter.format(
             source = source,
-            code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+            code = DiagnosticCode.TokenizerUnexpectedCharacter,
             line = line,
             column = column,
             unexpected = Some(lexeme),
@@ -79,7 +79,7 @@ object ParseDiagnostic:
             errorWidth = lexeme.length
         )
         ParseDiagnostic(
-            code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+            code = DiagnosticCode.TokenizerUnexpectedCharacter,
             span = SourceSpan(start = offset, end = offset + lexeme.length, line = line, column = column),
             message = formatted.message,
             expected = Nil,

--- a/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
@@ -16,7 +16,7 @@ final case class ParseDiagnostic(
 object ParseDiagnostic:
 
     def unexpectedEndOfInput(source: String, line: Int, column: Int, expected: List[String]): ParseDiagnostic =
-        val start     = SourceOffsets.offsetAt(source, line, column)
+        val start = SourceOffsets.offsetAt(source, line, column)
         val formatted = DiagnosticMessageFormatter.format(
             source = source,
             code = DiagnosticCode.UnexpectedEndOfInput,
@@ -44,8 +44,8 @@ object ParseDiagnostic:
         unexpected: String,
         expected: List[String]
     ): ParseDiagnostic =
-        val start     = SourceOffsets.offsetAt(source, line, column)
-        val end       = (start + width.max(1)).min(source.length.max(start + 1))
+        val start = SourceOffsets.offsetAt(source, line, column)
+        val end   = (start + width.max(1)).min(source.length.max(start + 1))
         val formatted = DiagnosticMessageFormatter.format(
             source = source,
             code = DiagnosticCode.UnexpectedToken,

--- a/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
@@ -7,7 +7,8 @@ final case class ParseDiagnostic(
     span: SourceSpan,
     message: String,
     expected: List[String],
-    suggestion: Option[String] = None
+    suggestion: Option[String] = None,
+    contextLines: List[DiagnosticContextLine] = Nil
 ) derives CanEqual:
 
     def toCompilerSpan: Span = Span(start = span.start, end = span.end)
@@ -15,22 +16,24 @@ final case class ParseDiagnostic(
 object ParseDiagnostic:
 
     def unexpectedEndOfInput(source: String, line: Int, column: Int, expected: List[String]): ParseDiagnostic =
-        val start = SourceOffsets.offsetAt(source, line, column)
+        val start     = SourceOffsets.offsetAt(source, line, column)
+        val formatted = DiagnosticMessageFormatter.format(
+            source = source,
+            code = DiagnosticCodes.UnexpectedEndOfInput,
+            line = line,
+            column = column,
+            unexpected = Some("end of input"),
+            expected = expected,
+            reasons = Nil,
+            suggestion = None,
+            errorWidth = 0
+        )
         ParseDiagnostic(
             code = DiagnosticCodes.UnexpectedEndOfInput,
             span = SourceSpan(start = start, end = start, line = line, column = column),
-            message = DiagnosticMessageFormatter.format(
-                source = source,
-                code = DiagnosticCodes.UnexpectedEndOfInput,
-                line = line,
-                column = column,
-                unexpected = Some("end of input"),
-                expected = expected,
-                reasons = Nil,
-                suggestion = None,
-                errorWidth = 0
-            ),
-            expected = expected
+            message = formatted.message,
+            expected = expected,
+            contextLines = formatted.contextLines
         )
 
     def unexpectedToken(
@@ -41,40 +44,44 @@ object ParseDiagnostic:
         unexpected: String,
         expected: List[String]
     ): ParseDiagnostic =
-        val start = SourceOffsets.offsetAt(source, line, column)
-        val end   = (start + width.max(1)).min(source.length.max(start + 1))
+        val start     = SourceOffsets.offsetAt(source, line, column)
+        val end       = (start + width.max(1)).min(source.length.max(start + 1))
+        val formatted = DiagnosticMessageFormatter.format(
+            source = source,
+            code = DiagnosticCodes.UnexpectedToken,
+            line = line,
+            column = column,
+            unexpected = Some(unexpected),
+            expected = expected,
+            reasons = Nil,
+            suggestion = None,
+            errorWidth = width
+        )
         ParseDiagnostic(
             code = DiagnosticCodes.UnexpectedToken,
             span = SourceSpan(start = start, end = end, line = line, column = column),
-            message = DiagnosticMessageFormatter.format(
-                source = source,
-                code = DiagnosticCodes.UnexpectedToken,
-                line = line,
-                column = column,
-                unexpected = Some(unexpected),
-                expected = expected,
-                reasons = Nil,
-                suggestion = None,
-                errorWidth = width
-            ),
-            expected = expected
+            message = formatted.message,
+            expected = expected,
+            contextLines = formatted.contextLines
         )
 
     def tokenizerUnexpectedCharacter(source: String, offset: Int, lexeme: String): ParseDiagnostic =
         val (line, column) = SourceOffsets.lineColumnAt(source, offset)
+        val formatted = DiagnosticMessageFormatter.format(
+            source = source,
+            code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+            line = line,
+            column = column,
+            unexpected = Some(lexeme),
+            expected = Nil,
+            reasons = Nil,
+            suggestion = None,
+            errorWidth = lexeme.length
+        )
         ParseDiagnostic(
             code = DiagnosticCodes.TokenizerUnexpectedCharacter,
             span = SourceSpan(start = offset, end = offset + lexeme.length, line = line, column = column),
-            message = DiagnosticMessageFormatter.format(
-                source = source,
-                code = DiagnosticCodes.TokenizerUnexpectedCharacter,
-                line = line,
-                column = column,
-                unexpected = Some(lexeme),
-                expected = Nil,
-                reasons = Nil,
-                suggestion = None,
-                errorWidth = lexeme.length
-            ),
-            expected = Nil
+            message = formatted.message,
+            expected = Nil,
+            contextLines = formatted.contextLines
         )

--- a/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
@@ -19,8 +19,17 @@ object ParseDiagnostic:
         ParseDiagnostic(
             code = DiagnosticCodes.UnexpectedEndOfInput,
             span = SourceSpan(start = start, end = start, line = line, column = column),
-            message =
-                formatMessage(line, column, unexpected = Some("end of input"), expected = expected, reasons = Nil),
+            message = DiagnosticMessageFormatter.format(
+                source = source,
+                code = DiagnosticCodes.UnexpectedEndOfInput,
+                line = line,
+                column = column,
+                unexpected = Some("end of input"),
+                expected = expected,
+                reasons = Nil,
+                suggestion = None,
+                errorWidth = 0
+            ),
             expected = expected
         )
 
@@ -37,7 +46,17 @@ object ParseDiagnostic:
         ParseDiagnostic(
             code = DiagnosticCodes.UnexpectedToken,
             span = SourceSpan(start = start, end = end, line = line, column = column),
-            message = formatMessage(line, column, unexpected = Some(unexpected), expected = expected, reasons = Nil),
+            message = DiagnosticMessageFormatter.format(
+                source = source,
+                code = DiagnosticCodes.UnexpectedToken,
+                line = line,
+                column = column,
+                unexpected = Some(unexpected),
+                expected = expected,
+                reasons = Nil,
+                suggestion = None,
+                errorWidth = width
+            ),
             expected = expected
         )
 
@@ -46,26 +65,16 @@ object ParseDiagnostic:
         ParseDiagnostic(
             code = DiagnosticCodes.TokenizerUnexpectedCharacter,
             span = SourceSpan(start = offset, end = offset + lexeme.length, line = line, column = column),
-            message = s"Unexpected character '$lexeme'",
+            message = DiagnosticMessageFormatter.format(
+                source = source,
+                code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+                line = line,
+                column = column,
+                unexpected = Some(lexeme),
+                expected = Nil,
+                reasons = Nil,
+                suggestion = None,
+                errorWidth = lexeme.length
+            ),
             expected = Nil
         )
-
-    private def formatMessage(
-        line: Int,
-        column: Int,
-        unexpected: Option[String],
-        expected: List[String],
-        reasons: Seq[String]
-    ): String =
-        val header         = s"(line $line, column $column):"
-        val unexpectedLine = unexpected.map(u => s"  unexpected $u")
-        val expectedLine =
-            if expected.isEmpty then None
-            else Some(s"  expected ${formatExpected(expected)}")
-        val reasonLines = reasons.map(r => s"  $r")
-        (header :: unexpectedLine.toList ::: expectedLine.toList ::: reasonLines.toList).mkString("\n")
-
-    private def formatExpected(items: List[String]): String =
-        if items.isEmpty then ""
-        else if items.size == 1 then items.head
-        else items.init.mkString(", ") + s", or ${items.last}"

--- a/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/ParseDiagnostic.scala
@@ -1,0 +1,71 @@
+package io.eleven19.krueger.compiler
+
+final case class SourceSpan(start: Int, end: Int, line: Int, column: Int) derives CanEqual
+
+final case class ParseDiagnostic(
+    code: String,
+    span: SourceSpan,
+    message: String,
+    expected: List[String],
+    suggestion: Option[String] = None
+) derives CanEqual:
+
+    def toCompilerSpan: Span = Span(start = span.start, end = span.end)
+
+object ParseDiagnostic:
+
+    def unexpectedEndOfInput(source: String, line: Int, column: Int, expected: List[String]): ParseDiagnostic =
+        val start = SourceOffsets.offsetAt(source, line, column)
+        ParseDiagnostic(
+            code = DiagnosticCodes.UnexpectedEndOfInput,
+            span = SourceSpan(start = start, end = start, line = line, column = column),
+            message =
+                formatMessage(line, column, unexpected = Some("end of input"), expected = expected, reasons = Nil),
+            expected = expected
+        )
+
+    def unexpectedToken(
+        source: String,
+        line: Int,
+        column: Int,
+        width: Int,
+        unexpected: String,
+        expected: List[String]
+    ): ParseDiagnostic =
+        val start = SourceOffsets.offsetAt(source, line, column)
+        val end   = (start + width.max(1)).min(source.length.max(start + 1))
+        ParseDiagnostic(
+            code = DiagnosticCodes.UnexpectedToken,
+            span = SourceSpan(start = start, end = end, line = line, column = column),
+            message = formatMessage(line, column, unexpected = Some(unexpected), expected = expected, reasons = Nil),
+            expected = expected
+        )
+
+    def tokenizerUnexpectedCharacter(source: String, offset: Int, lexeme: String): ParseDiagnostic =
+        val (line, column) = SourceOffsets.lineColumnAt(source, offset)
+        ParseDiagnostic(
+            code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+            span = SourceSpan(start = offset, end = offset + lexeme.length, line = line, column = column),
+            message = s"Unexpected character '$lexeme'",
+            expected = Nil
+        )
+
+    private def formatMessage(
+        line: Int,
+        column: Int,
+        unexpected: Option[String],
+        expected: List[String],
+        reasons: Seq[String]
+    ): String =
+        val header         = s"(line $line, column $column):"
+        val unexpectedLine = unexpected.map(u => s"  unexpected $u")
+        val expectedLine =
+            if expected.isEmpty then None
+            else Some(s"  expected ${formatExpected(expected)}")
+        val reasonLines = reasons.map(r => s"  $r")
+        (header :: unexpectedLine.toList ::: expectedLine.toList ::: reasonLines.toList).mkString("\n")
+
+    private def formatExpected(items: List[String]): String =
+        if items.isEmpty then ""
+        else if items.size == 1 then items.head
+        else items.init.mkString(", ") + s", or ${items.last}"

--- a/krueger/core/src/io/eleven19/krueger/compiler/SourceOffsets.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/SourceOffsets.scala
@@ -1,11 +1,5 @@
 package io.eleven19.krueger.compiler
 
-object DiagnosticCodes:
-    val UnexpectedEndOfInput: String         = "ELM-P001"
-    val UnexpectedToken: String              = "ELM-P002"
-    val SpecialisedParseFailure: String      = "ELM-P003"
-    val TokenizerUnexpectedCharacter: String = "ELM-T001"
-
 object SourceOffsets:
 
     /** Convert 1-based line/column to a 0-based character offset in `source`. */

--- a/krueger/core/src/io/eleven19/krueger/compiler/SourceOffsets.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/SourceOffsets.scala
@@ -1,0 +1,39 @@
+package io.eleven19.krueger.compiler
+
+object DiagnosticCodes:
+    val UnexpectedEndOfInput: String         = "ELM-P001"
+    val UnexpectedToken: String              = "ELM-P002"
+    val SpecialisedParseFailure: String      = "ELM-P003"
+    val TokenizerUnexpectedCharacter: String = "ELM-T001"
+
+object SourceOffsets:
+
+    /** Convert 1-based line/column to a 0-based character offset in `source`. */
+    def offsetAt(source: String, line: Int, column: Int): Int =
+        require(line >= 1 && column >= 1, s"line and column are 1-based, got ($line, $column)")
+        var currentLine = 1
+        var index       = 0
+        while index < source.length && currentLine < line do
+            if source.charAt(index) == '\n' then currentLine += 1
+            index += 1
+        if currentLine != line then source.length
+        else
+            val lineStart = index
+            var col       = 1
+            while col < column && index < source.length && source.charAt(index) != '\n' do
+                index += 1
+                col += 1
+            index.min(source.length).max(lineStart)
+
+    def lineColumnAt(source: String, offset: Int): (Int, Int) =
+        val bounded = offset.max(0).min(source.length)
+        var line    = 1
+        var column  = 1
+        var index   = 0
+        while index < bounded do
+            if source.charAt(index) == '\n' then
+                line += 1
+                column = 1
+            else column += 1
+            index += 1
+        (line, column)

--- a/krueger/core/src/io/eleven19/krueger/compiler/SourceSnippetBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/compiler/SourceSnippetBuilder.scala
@@ -1,0 +1,54 @@
+package io.eleven19.krueger.compiler
+
+final case class SourceSnippet(
+    contextLines: List[DiagnosticContextLine],
+    rendered: String
+) derives CanEqual
+
+/** Builds multi-line source snippets with aligned gutters and a caret on the error line. */
+object SourceSnippetBuilder:
+
+    val DefaultLinesBefore: Int = 2
+    val DefaultLinesAfter: Int  = 1
+
+    def build(
+        source: String,
+        errorLine: Int,
+        column: Int,
+        errorWidth: Int,
+        linesBefore: Int = DefaultLinesBefore,
+        linesAfter: Int = DefaultLinesAfter
+    ): SourceSnippet =
+        val lines       = sourceLines(source)
+        val totalLines  = lines.length.max(1)
+        val boundedLine = errorLine.max(1).min(totalLines)
+        val startLine   = (boundedLine - linesBefore).max(1)
+        val endLine     = (boundedLine + linesAfter).min(totalLines)
+        val gutterWidth = endLine.toString.length
+        val contextLines =
+            (startLine to endLine).toList.map { lineNumber =>
+                DiagnosticContextLine(
+                    line = lineNumber,
+                    text = lines.lift(lineNumber - 1).getOrElse(""),
+                    isErrorLine = lineNumber == boundedLine
+                )
+            }
+        val renderedLines =
+            contextLines.map(line => s"${paddedLineNumber(line.line, gutterWidth)}| ${line.text}")
+        val caret =
+            val gutterPrefix = paddedLineNumber(boundedLine, gutterWidth) + "| "
+            val caretStart   = gutterPrefix.length + (column - 1).max(0)
+            val caretWidth   = if errorWidth <= 0 then 1 else errorWidth
+            " " * caretStart + ("^" * caretWidth)
+        SourceSnippet(
+            contextLines = contextLines,
+            rendered = (renderedLines :+ caret).mkString("\n")
+        )
+
+    private def sourceLines(source: String): Vector[String] =
+        if source.isEmpty then Vector("")
+        else if source.endsWith("\n") then source.linesIterator.toVector :+ ""
+        else source.linesIterator.toVector
+
+    private def paddedLineNumber(line: Int, width: Int): String =
+        line.toString.reverse.padTo(width, ' ').reverse

--- a/krueger/core/src/io/eleven19/krueger/lexer/ElmTokenizer.scala
+++ b/krueger/core/src/io/eleven19/krueger/lexer/ElmTokenizer.scala
@@ -1,7 +1,7 @@
 package io.eleven19.krueger.lexer
 
 import io.eleven19.krueger.compiler.CompileError
-import io.eleven19.krueger.compiler.Span
+import io.eleven19.krueger.compiler.ParseDiagnostic
 import io.eleven19.krueger.trees.query.QueryLogic
 
 final case class ElmTokenizerConfig(
@@ -153,8 +153,7 @@ object ElmTokenizer:
         val lexeme = source.substring(start, start + 1)
         val err = CompileError.ParseError(
             phase = "tokenize",
-            message = s"Unexpected character '$lexeme'",
-            span = Some(Span(start, start + 1))
+            diagnostic = ParseDiagnostic.tokenizerUnexpectedCharacter(source, start, lexeme)
         )
         if config.recoverUnknown then
             for _ <- QueryLogic.log[TokenizeCtx, TokenizeLog, TokenizeErr](

--- a/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
@@ -71,7 +71,7 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         val message =
             body match
                 case DiagnosticBody.Vanilla(_, _, rsns, w) =>
-                    DiagnosticMessageFormatter.format(
+                    val formatted = DiagnosticMessageFormatter.format(
                         source = src,
                         code = code,
                         line = line,
@@ -82,8 +82,9 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
                         suggestion = suggestion,
                         errorWidth = w
                     )
+                    formatted.message -> formatted.contextLines
                 case DiagnosticBody.Specialised(msgs, w) =>
-                    DiagnosticMessageFormatter.format(
+                    val formatted = DiagnosticMessageFormatter.format(
                         source = src,
                         code = code,
                         line = line,
@@ -94,12 +95,14 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
                         suggestion = suggestion,
                         errorWidth = w
                     )
+                    formatted.message -> formatted.contextLines
         ParseDiagnostic(
             code = code,
             span = SourceSpan(start = start, end = end, line = line, column = column),
-            message = message,
+            message = message._1,
             expected = expected,
-            suggestion = suggestion
+            suggestion = suggestion,
+            contextLines = message._2
         )
 
     def vanillaError(

--- a/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
@@ -1,6 +1,5 @@
 package io.eleven19.krueger.parser
 
-import parsley.errors.DefaultErrorBuilder
 import parsley.errors.ErrorBuilder
 import parsley.errors.tokenextractors.SingleChar
 
@@ -36,8 +35,6 @@ object ParseDiagnosticContext:
 /** Builds structured [[ParseDiagnostic]] values from Parsley failures for a single parse invocation. */
 final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilder[ParseDiagnostic] with SingleChar:
 
-    private val stringBuilder = new DefaultErrorBuilder with SingleChar {}
-
     type Position       = (Int, Int)
     type Source         = Unit
     type ErrorInfoLines = DiagnosticBody
@@ -71,28 +68,31 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         val end =
             if unexpected.contains(endOfInput) then start
             else (start + width.max(1)).min(src.length.max(start + 1))
-        val sourceLine = lineAt(src, line)
         val message =
             body match
-                case DiagnosticBody.Vanilla(unexp, exp, rsns, _) =>
-                    stringBuilder.format(
-                        stringBuilder.pos(line, column),
-                        stringBuilder.source(None),
-                        stringBuilder.vanillaError(
-                            stringBuilder.unexpected(unexp),
-                            stringBuilder.expected(stringBuilder.combineExpectedItems(exp)),
-                            rsns,
-                            stringBuilder.lineInfo(sourceLine, Nil, Nil, column - 1, width)
-                        )
+                case DiagnosticBody.Vanilla(_, _, rsns, w) =>
+                    DiagnosticMessageFormatter.format(
+                        source = src,
+                        code = code,
+                        line = line,
+                        column = column,
+                        unexpected = unexpected,
+                        expected = expected,
+                        reasons = rsns,
+                        suggestion = suggestion,
+                        errorWidth = w
                     )
-                case DiagnosticBody.Specialised(msgs, _) =>
-                    stringBuilder.format(
-                        stringBuilder.pos(line, column),
-                        stringBuilder.source(None),
-                        stringBuilder.specialisedError(
-                            msgs,
-                            stringBuilder.lineInfo(sourceLine, Nil, Nil, column - 1, width)
-                        )
+                case DiagnosticBody.Specialised(msgs, w) =>
+                    DiagnosticMessageFormatter.format(
+                        source = src,
+                        code = code,
+                        line = line,
+                        column = column,
+                        unexpected = None,
+                        expected = Nil,
+                        reasons = msgs,
+                        suggestion = suggestion,
+                        errorWidth = w
                     )
         ParseDiagnostic(
             code = code,
@@ -145,12 +145,6 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         errorPointsAt: Int,
         errorWidth: Int
     ): LineInfo = errorWidth
-
-    private def lineAt(source: String, oneBasedLine: Int): String =
-        if source.isEmpty then ""
-        else
-            val lines = source.linesIterator.toVector
-            lines.lift(oneBasedLine - 1).getOrElse("")
 
     private def classify(unexpected: Option[Item]): String =
         unexpected match

--- a/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
@@ -1,0 +1,168 @@
+package io.eleven19.krueger.parser
+
+import parsley.errors.DefaultErrorBuilder
+import parsley.errors.ErrorBuilder
+import parsley.errors.tokenextractors.SingleChar
+
+import io.eleven19.krueger.compiler.*
+
+sealed trait DiagnosticBody derives CanEqual
+
+object DiagnosticBody:
+
+    final case class Vanilla(
+        unexpected: Option[String],
+        expected: Set[String],
+        reasons: Seq[String],
+        errorWidth: Int
+    ) extends DiagnosticBody
+
+    final case class Specialised(messages: Seq[String], errorWidth: Int) extends DiagnosticBody
+
+/** Threads the active source through Parsley error construction so diagnostics can compute offsets. */
+object ParseDiagnosticContext:
+
+    private val activeSource = new ThreadLocal[String]
+
+    def withSource[A](source: String)(thunk: => A): A =
+        activeSource.set(source)
+        try thunk
+        finally activeSource.remove()
+
+    private[parser] def source: String =
+        val value = activeSource.get()
+        if value == null then "" else value
+
+/** Builds structured [[ParseDiagnostic]] values from Parsley failures for a single parse invocation. */
+final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilder[ParseDiagnostic] with SingleChar:
+
+    private val stringBuilder = new DefaultErrorBuilder with SingleChar {}
+
+    type Position       = (Int, Int)
+    type Source         = Unit
+    type ErrorInfoLines = DiagnosticBody
+    type Item           = String
+    type Raw            = String
+    type Named          = String
+    type EndOfInput     = String
+    type Message        = String
+    type Messages       = Seq[Message]
+    type ExpectedItems  = Set[Item]
+    type ExpectedLine   = Set[Item]
+    type UnexpectedLine = Option[Item]
+    type LineInfo       = Int
+
+    def format(pos: Position, source: Unit, body: ErrorInfoLines): ParseDiagnostic =
+        val src            = parseSource
+        val (line, column) = pos
+        val start          = SourceOffsets.offsetAt(src, line, column)
+        val (code, unexpected, expected, reasons, suggestion, width) = body match
+            case DiagnosticBody.Vanilla(unexp, exp, rsns, w) =>
+                (
+                    classify(unexp),
+                    unexp,
+                    exp.toList.sorted,
+                    rsns,
+                    suggestionFor(unexp, exp, rsns),
+                    w
+                )
+            case DiagnosticBody.Specialised(msgs, w) =>
+                (DiagnosticCodes.SpecialisedParseFailure, None, Nil, msgs, None, w)
+        val end =
+            if unexpected.contains(endOfInput) then start
+            else (start + width.max(1)).min(src.length.max(start + 1))
+        val message =
+            body match
+                case DiagnosticBody.Vanilla(unexp, exp, rsns, _) =>
+                    stringBuilder.format(
+                        stringBuilder.pos(line, column),
+                        stringBuilder.source(None),
+                        stringBuilder.vanillaError(
+                            stringBuilder.unexpected(unexp),
+                            stringBuilder.expected(stringBuilder.combineExpectedItems(exp)),
+                            rsns,
+                            stringBuilder.lineInfo("", Nil, Nil, column - 1, width)
+                        )
+                    )
+                case DiagnosticBody.Specialised(msgs, _) =>
+                    stringBuilder.format(
+                        stringBuilder.pos(line, column),
+                        stringBuilder.source(None),
+                        stringBuilder.specialisedError(
+                            msgs,
+                            stringBuilder.lineInfo("", Nil, Nil, column - 1, width)
+                        )
+                    )
+        ParseDiagnostic(
+            code = code,
+            span = SourceSpan(start = start, end = end, line = line, column = column),
+            message = message,
+            expected = expected,
+            suggestion = suggestion
+        )
+
+    def vanillaError(
+        unexpected: UnexpectedLine,
+        expected: ExpectedLine,
+        reasons: Messages,
+        line: LineInfo
+    ): ErrorInfoLines =
+        DiagnosticBody.Vanilla(unexpected, expected, reasons, line)
+
+    def specialisedError(msgs: Messages, line: LineInfo): ErrorInfoLines =
+        DiagnosticBody.Specialised(msgs, line)
+
+    def pos(line: Int, col: Int): Position = (line, col)
+
+    def source(sourceName: Option[String]): Source = ()
+
+    def combineExpectedItems(alts: Set[Item]): ExpectedLine = alts
+
+    def combineMessages(alts: Seq[Message]): Messages = alts
+
+    def unexpected(item: Option[Item]): UnexpectedLine = item
+
+    def expected(alts: ExpectedLine): ExpectedLine = alts
+
+    def reason(reason: String): Message = reason
+
+    def message(msg: String): Message = msg
+
+    def raw(item: String): Raw = item
+
+    def named(item: String): Named = item
+
+    val endOfInput: EndOfInput = "end of input"
+
+    val numLinesBefore: Int = 0
+    val numLinesAfter: Int  = 0
+
+    def lineInfo(
+        line: String,
+        linesBefore: Seq[String],
+        linesAfter: Seq[String],
+        errorPointsAt: Int,
+        errorWidth: Int
+    ): LineInfo = errorWidth
+
+    private def classify(unexpected: Option[Item]): String =
+        unexpected match
+            case Some(`endOfInput`) => DiagnosticCodes.UnexpectedEndOfInput
+            case Some(_)            => DiagnosticCodes.UnexpectedToken
+            case None               => DiagnosticCodes.UnexpectedToken
+
+    private def suggestionFor(
+        unexpected: Option[Item],
+        expected: Set[Item],
+        reasons: Seq[String]
+    ): Option[String] =
+        reasons.headOption.orElse {
+            if unexpected.contains(endOfInput) && expected.exists(_.contains("in")) then
+                Some("Did you forget `in` after a `let` binding?")
+            else None
+        }
+
+object ParseDiagnosticErrorBuilder:
+
+    def apply(source: String): ParseDiagnosticErrorBuilder =
+        new ParseDiagnosticErrorBuilder(source)

--- a/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
@@ -71,6 +71,7 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         val end =
             if unexpected.contains(endOfInput) then start
             else (start + width.max(1)).min(src.length.max(start + 1))
+        val sourceLine = lineAt(src, line)
         val message =
             body match
                 case DiagnosticBody.Vanilla(unexp, exp, rsns, _) =>
@@ -81,7 +82,7 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
                             stringBuilder.unexpected(unexp),
                             stringBuilder.expected(stringBuilder.combineExpectedItems(exp)),
                             rsns,
-                            stringBuilder.lineInfo("", Nil, Nil, column - 1, width)
+                            stringBuilder.lineInfo(sourceLine, Nil, Nil, column - 1, width)
                         )
                     )
                 case DiagnosticBody.Specialised(msgs, _) =>
@@ -90,7 +91,7 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
                         stringBuilder.source(None),
                         stringBuilder.specialisedError(
                             msgs,
-                            stringBuilder.lineInfo("", Nil, Nil, column - 1, width)
+                            stringBuilder.lineInfo(sourceLine, Nil, Nil, column - 1, width)
                         )
                     )
         ParseDiagnostic(
@@ -144,6 +145,12 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         errorPointsAt: Int,
         errorWidth: Int
     ): LineInfo = errorWidth
+
+    private def lineAt(source: String, oneBasedLine: Int): String =
+        if source.isEmpty then ""
+        else
+            val lines = source.linesIterator.toVector
+            lines.lift(oneBasedLine - 1).getOrElse("")
 
     private def classify(unexpected: Option[Item]): String =
         unexpected match

--- a/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
+++ b/krueger/core/src/io/eleven19/krueger/parser/ParseDiagnosticErrorBuilder.scala
@@ -64,7 +64,7 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
                     w
                 )
             case DiagnosticBody.Specialised(msgs, w) =>
-                (DiagnosticCodes.SpecialisedParseFailure, None, Nil, msgs, None, w)
+                (DiagnosticCode.SpecialisedParseFailure, None, Nil, msgs, None, w)
         val end =
             if unexpected.contains(endOfInput) then start
             else (start + width.max(1)).min(src.length.max(start + 1))
@@ -149,11 +149,11 @@ final class ParseDiagnosticErrorBuilder(parseSource: String) extends ErrorBuilde
         errorWidth: Int
     ): LineInfo = errorWidth
 
-    private def classify(unexpected: Option[Item]): String =
+    private def classify(unexpected: Option[Item]): DiagnosticCode =
         unexpected match
-            case Some(`endOfInput`) => DiagnosticCodes.UnexpectedEndOfInput
-            case Some(_)            => DiagnosticCodes.UnexpectedToken
-            case None               => DiagnosticCodes.UnexpectedToken
+            case Some(`endOfInput`) => DiagnosticCode.UnexpectedEndOfInput
+            case Some(_)            => DiagnosticCode.UnexpectedToken
+            case None               => DiagnosticCode.UnexpectedToken
 
     private def suggestionFor(
         unexpected: Option[Item],

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticCodeSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticCodeSpec.scala
@@ -1,0 +1,42 @@
+package io.eleven19.krueger.compiler
+
+import zio.test.*
+
+object DiagnosticCodeSpec extends ZIOSpecDefault:
+
+    def spec = suite("DiagnosticCode")(
+        suite("validation")(
+            test("accepts stable parse and tokenizer codes") {
+                assertTrue(
+                    DiagnosticCode.make("ELM-P001").isRight,
+                    DiagnosticCode.make("ELM-P002").isRight,
+                    DiagnosticCode.make("ELM-P003").isRight,
+                    DiagnosticCode.make("ELM-T001").isRight
+                )
+            },
+            test("rejects arbitrary strings") {
+                assertTrue(
+                    DiagnosticCode.make("").isLeft,
+                    DiagnosticCode.make("PARSE_ERROR").isLeft,
+                    DiagnosticCode.make("ELM-X001").isLeft,
+                    DiagnosticCode.make("ELM-P01").isLeft
+                )
+            }
+        ),
+        suite("known codes")(
+            test("exposes the current stable diagnostic codes") {
+                assertTrue(
+                    DiagnosticCode.unwrap(DiagnosticCode.UnexpectedEndOfInput) == "ELM-P001",
+                    DiagnosticCode.unwrap(DiagnosticCode.UnexpectedToken) == "ELM-P002",
+                    DiagnosticCode.unwrap(DiagnosticCode.SpecialisedParseFailure) == "ELM-P003",
+                    DiagnosticCode.unwrap(DiagnosticCode.TokenizerUnexpectedCharacter) == "ELM-T001"
+                )
+            },
+            test("classifies tokenizer codes for message formatting") {
+                assertTrue(
+                    DiagnosticCode.isTokenizer(DiagnosticCode.TokenizerUnexpectedCharacter),
+                    !DiagnosticCode.isTokenizer(DiagnosticCode.UnexpectedEndOfInput)
+                )
+            }
+        )
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
@@ -10,7 +10,7 @@ object DiagnosticMessageFormatterSpec extends ZIOSpecDefault:
         test("formats unexpected end of input with surrounding context and expected tokens") {
             val formatted = DiagnosticMessageFormatter.format(
                 source = malformedSource,
-                code = DiagnosticCodes.UnexpectedEndOfInput,
+                code = DiagnosticCode.UnexpectedEndOfInput,
                 line = 3,
                 column = 4,
                 unexpected = Some("end of input"),
@@ -41,7 +41,7 @@ I was expecting one of the following:
         test("formats tokenizer unexpected character errors with surrounding context") {
             val formatted = DiagnosticMessageFormatter.format(
                 source = "main @",
-                code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+                code = DiagnosticCode.TokenizerUnexpectedCharacter,
                 line = 1,
                 column = 6,
                 unexpected = Some("@"),
@@ -65,7 +65,7 @@ I ran into an unexpected character:
         test("appends hints when provided") {
             val formatted = DiagnosticMessageFormatter.format(
                 source = "let x = 1",
-                code = DiagnosticCodes.UnexpectedEndOfInput,
+                code = DiagnosticCode.UnexpectedEndOfInput,
                 line = 1,
                 column = 10,
                 unexpected = Some("end of input"),

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
@@ -1,0 +1,76 @@
+package io.eleven19.krueger.compiler
+
+import zio.test.*
+
+object DiagnosticMessageFormatterSpec extends ZIOSpecDefault:
+
+    private val malformedSource = "module M exposing (..)\n\nx ="
+
+    def spec = suite("DiagnosticMessageFormatter")(
+        test("formats unexpected end of input with source snippet and expected tokens") {
+            val message = DiagnosticMessageFormatter.format(
+                source = malformedSource,
+                code = DiagnosticCodes.UnexpectedEndOfInput,
+                line = 3,
+                column = 4,
+                unexpected = Some("end of input"),
+                expected = List("identifier", "digit"),
+                reasons = Nil,
+                suggestion = None,
+                errorWidth = 0
+            )
+            assertTrue(
+                message == """-- PARSE ERROR (ELM-P001) at line 3, column 4
+
+I ran into the end of the file unexpectedly.
+
+I was expecting one of the following:
+
+    identifier
+    digit
+
+3| x =
+      ^"""
+            )
+        },
+        test("formats tokenizer unexpected character errors") {
+            val message = DiagnosticMessageFormatter.format(
+                source = "main @",
+                code = DiagnosticCodes.TokenizerUnexpectedCharacter,
+                line = 1,
+                column = 6,
+                unexpected = Some("@"),
+                expected = Nil,
+                reasons = Nil,
+                suggestion = None,
+                errorWidth = 1
+            )
+            assertTrue(
+                message == """-- TOKENIZE ERROR (ELM-T001) at line 1, column 6
+
+I ran into an unexpected character:
+
+    @
+
+1| main @
+        ^"""
+            )
+        },
+        test("appends hints when provided") {
+            val message = DiagnosticMessageFormatter.format(
+                source = "let x = 1",
+                code = DiagnosticCodes.UnexpectedEndOfInput,
+                line = 1,
+                column = 10,
+                unexpected = Some("end of input"),
+                expected = List("in"),
+                reasons = Nil,
+                suggestion = Some("Did you forget `in` after a `let` binding?"),
+                errorWidth = 0
+            )
+            assertTrue(
+                message.endsWith("Hint: Did you forget `in` after a `let` binding?"),
+                message.contains("I was expecting one of the following:")
+            )
+        }
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/DiagnosticMessageFormatterSpec.scala
@@ -7,8 +7,8 @@ object DiagnosticMessageFormatterSpec extends ZIOSpecDefault:
     private val malformedSource = "module M exposing (..)\n\nx ="
 
     def spec = suite("DiagnosticMessageFormatter")(
-        test("formats unexpected end of input with source snippet and expected tokens") {
-            val message = DiagnosticMessageFormatter.format(
+        test("formats unexpected end of input with surrounding context and expected tokens") {
+            val formatted = DiagnosticMessageFormatter.format(
                 source = malformedSource,
                 code = DiagnosticCodes.UnexpectedEndOfInput,
                 line = 3,
@@ -20,7 +20,7 @@ object DiagnosticMessageFormatterSpec extends ZIOSpecDefault:
                 errorWidth = 0
             )
             assertTrue(
-                message == """-- PARSE ERROR (ELM-P001) at line 3, column 4
+                formatted.message == """-- PARSE ERROR (ELM-P001) at line 3, column 4
 
 I ran into the end of the file unexpectedly.
 
@@ -29,12 +29,17 @@ I was expecting one of the following:
     identifier
     digit
 
+1| module M exposing (..)
+2| 
 3| x =
-      ^"""
+      ^""",
+                formatted.contextLines.map(_.line) == List(1, 2, 3),
+                formatted.contextLines.count(_.isErrorLine) == 1,
+                formatted.contextLines.find(_.isErrorLine).exists(_.text == "x =")
             )
         },
-        test("formats tokenizer unexpected character errors") {
-            val message = DiagnosticMessageFormatter.format(
+        test("formats tokenizer unexpected character errors with surrounding context") {
+            val formatted = DiagnosticMessageFormatter.format(
                 source = "main @",
                 code = DiagnosticCodes.TokenizerUnexpectedCharacter,
                 line = 1,
@@ -46,18 +51,19 @@ I was expecting one of the following:
                 errorWidth = 1
             )
             assertTrue(
-                message == """-- TOKENIZE ERROR (ELM-T001) at line 1, column 6
+                formatted.message == """-- TOKENIZE ERROR (ELM-T001) at line 1, column 6
 
 I ran into an unexpected character:
 
     @
 
 1| main @
-        ^"""
+        ^""",
+                formatted.contextLines == List(DiagnosticContextLine(1, "main @", isErrorLine = true))
             )
         },
         test("appends hints when provided") {
-            val message = DiagnosticMessageFormatter.format(
+            val formatted = DiagnosticMessageFormatter.format(
                 source = "let x = 1",
                 code = DiagnosticCodes.UnexpectedEndOfInput,
                 line = 1,
@@ -69,8 +75,8 @@ I ran into an unexpected character:
                 errorWidth = 0
             )
             assertTrue(
-                message.endsWith("Hint: Did you forget `in` after a `let` binding?"),
-                message.contains("I was expecting one of the following:")
+                formatted.message.endsWith("Hint: Did you forget `in` after a `let` binding?"),
+                formatted.message.contains("I was expecting one of the following:")
             )
         }
     )

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
@@ -1,0 +1,73 @@
+package io.eleven19.krueger.compiler
+
+import zio.test.*
+
+import io.eleven19.krueger.parser.{DiagnosticBody, ParseDiagnosticErrorBuilder}
+
+object ParseDiagnosticSpec extends ZIOSpecDefault:
+
+    def spec = suite("ParseDiagnostic")(
+        test("classifies unexpected end of input as ELM-P001") {
+            val diagnostic = ParseDiagnostic.unexpectedEndOfInput(
+                source = "module M",
+                line = 1,
+                column = 9,
+                expected = List("exposing", "where")
+            )
+            assertTrue(
+                diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                diagnostic.span.line == 1,
+                diagnostic.span.column == 9,
+                diagnostic.span.start == 8,
+                diagnostic.span.end == 8,
+                diagnostic.expected == List("exposing", "where"),
+                diagnostic.suggestion.isEmpty
+            )
+        },
+        test("classifies unexpected token as ELM-P002") {
+            val diagnostic = ParseDiagnostic.unexpectedToken(
+                source = "x = @",
+                line = 1,
+                column = 5,
+                width = 1,
+                unexpected = "@",
+                expected = List("identifier", "digit")
+            )
+            assertTrue(
+                diagnostic.code == DiagnosticCodes.UnexpectedToken,
+                diagnostic.span.start == 4,
+                diagnostic.span.end == 5,
+                diagnostic.message.contains("unexpected")
+            )
+        },
+        test("tokenizer unexpected character uses ELM-T001") {
+            val diagnostic = ParseDiagnostic.tokenizerUnexpectedCharacter(
+                source = "main @",
+                offset = 5,
+                lexeme = "@"
+            )
+            assertTrue(
+                diagnostic.code == DiagnosticCodes.TokenizerUnexpectedCharacter,
+                diagnostic.span.start == 5,
+                diagnostic.span.end == 6,
+                diagnostic.span.line == 1,
+                diagnostic.span.column == 6,
+                diagnostic.message.contains("Unexpected character '@'")
+            )
+        },
+        test("suggestion helper recognizes missing in after let") {
+            val diagnostic = ParseDiagnosticErrorBuilder("module M\n\nx = 1").format(
+                (3, 1),
+                (),
+                DiagnosticBody.Vanilla(
+                    unexpected = Some("end of input"),
+                    expected = Set("in", "identifier"),
+                    reasons = Nil,
+                    errorWidth = 0
+                )
+            )
+            assertTrue(
+                diagnostic.suggestion.contains("Did you forget `in` after a `let` binding?")
+            )
+        }
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
@@ -52,7 +52,8 @@ object ParseDiagnosticSpec extends ZIOSpecDefault:
                 diagnostic.span.end == 6,
                 diagnostic.span.line == 1,
                 diagnostic.span.column == 6,
-                diagnostic.message.contains("Unexpected character '@'")
+                diagnostic.message.contains("I ran into an unexpected character"),
+                diagnostic.message.contains("@")
             )
         },
         test("suggestion helper recognizes missing in after let") {

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/ParseDiagnosticSpec.scala
@@ -15,7 +15,7 @@ object ParseDiagnosticSpec extends ZIOSpecDefault:
                 expected = List("exposing", "where")
             )
             assertTrue(
-                diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                diagnostic.code == DiagnosticCode.UnexpectedEndOfInput,
                 diagnostic.span.line == 1,
                 diagnostic.span.column == 9,
                 diagnostic.span.start == 8,
@@ -34,7 +34,7 @@ object ParseDiagnosticSpec extends ZIOSpecDefault:
                 expected = List("identifier", "digit")
             )
             assertTrue(
-                diagnostic.code == DiagnosticCodes.UnexpectedToken,
+                diagnostic.code == DiagnosticCode.UnexpectedToken,
                 diagnostic.span.start == 4,
                 diagnostic.span.end == 5,
                 diagnostic.message.contains("unexpected")
@@ -47,7 +47,7 @@ object ParseDiagnosticSpec extends ZIOSpecDefault:
                 lexeme = "@"
             )
             assertTrue(
-                diagnostic.code == DiagnosticCodes.TokenizerUnexpectedCharacter,
+                diagnostic.code == DiagnosticCode.TokenizerUnexpectedCharacter,
                 diagnostic.span.start == 5,
                 diagnostic.span.end == 6,
                 diagnostic.span.line == 1,

--- a/krueger/core/test/src/io/eleven19/krueger/compiler/SourceSnippetBuilderSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/compiler/SourceSnippetBuilderSpec.scala
@@ -1,0 +1,49 @@
+package io.eleven19.krueger.compiler
+
+import zio.test.*
+
+object SourceSnippetBuilderSpec extends ZIOSpecDefault:
+
+    def spec = suite("SourceSnippetBuilder")(
+        test("includes two lines before and one line after when available") {
+            val source = "module Demo exposing (..)\n\nmain =\n"
+            val snippet = SourceSnippetBuilder.build(
+                source = source,
+                errorLine = 3,
+                column = 7,
+                errorWidth = 0
+            )
+            assertTrue(
+                snippet.contextLines.map(_.line) == List(1, 2, 3, 4),
+                snippet.contextLines.count(_.isErrorLine) == 1,
+                snippet.rendered.contains("1| module Demo exposing (..)"),
+                snippet.rendered.contains("3| main ="),
+                snippet.rendered.contains("4|"),
+                snippet.rendered.linesIterator.toList.last == "         ^"
+            )
+        },
+        test("clamps context at the start of the file") {
+            val snippet = SourceSnippetBuilder.build(
+                source = "module M",
+                errorLine = 1,
+                column = 7,
+                errorWidth = 0
+            )
+            assertTrue(
+                snippet.contextLines.map(_.line) == List(1),
+                snippet.rendered.startsWith("1| module M")
+            )
+        },
+        test("preserves a trailing empty line after a final newline") {
+            val snippet = SourceSnippetBuilder.build(
+                source = "x =\n",
+                errorLine = 2,
+                column = 1,
+                errorWidth = 0
+            )
+            assertTrue(
+                snippet.contextLines.exists(line => line.line == 2 && line.text.isEmpty),
+                snippet.rendered.contains("2| ")
+            )
+        }
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
@@ -72,8 +72,11 @@ object ElmTokenizerSpec extends ZIOSpecDefault:
             assertTrue(
                 result.value.isLeft,
                 result.errors.exists {
-                    case CompileError.ParseError("tokenize", message, Some(span)) =>
-                        message.contains("Unexpected character '@'") && span.start == 5 && span.end == 6
+                    case CompileError.ParseError("tokenize", diagnostic) =>
+                        diagnostic.code == "ELM-T001" &&
+                        diagnostic.message.contains("Unexpected character '@'") &&
+                        diagnostic.span.start == 5 &&
+                        diagnostic.span.end == 6
                     case _ => false
                 }
             )

--- a/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
@@ -74,7 +74,8 @@ object ElmTokenizerSpec extends ZIOSpecDefault:
                 result.errors.exists {
                     case CompileError.ParseError("tokenize", diagnostic) =>
                         diagnostic.code == "ELM-T001" &&
-                        diagnostic.message.contains("Unexpected character '@'") &&
+                        diagnostic.message.contains("I ran into an unexpected character") &&
+                        diagnostic.message.contains("@") &&
                         diagnostic.span.start == 5 &&
                         diagnostic.span.end == 6
                     case _ => false

--- a/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/lexer/ElmTokenizerSpec.scala
@@ -2,7 +2,7 @@ package io.eleven19.krueger.lexer
 
 import zio.test.*
 
-import io.eleven19.krueger.compiler.CompileError
+import io.eleven19.krueger.compiler.{CompileError, DiagnosticCode}
 
 object ElmTokenizerSpec extends ZIOSpecDefault:
 
@@ -73,7 +73,7 @@ object ElmTokenizerSpec extends ZIOSpecDefault:
                 result.value.isLeft,
                 result.errors.exists {
                     case CompileError.ParseError("tokenize", diagnostic) =>
-                        diagnostic.code == "ELM-T001" &&
+                        diagnostic.code == DiagnosticCode.TokenizerUnexpectedCharacter &&
                         diagnostic.message.contains("I ran into an unexpected character") &&
                         diagnostic.message.contains("@") &&
                         diagnostic.span.start == 5 &&

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
@@ -4,6 +4,7 @@ import parsley.{Failure, Success}
 import zio.test.*
 
 import io.eleven19.krueger.Krueger
+import io.eleven19.krueger.compiler.DiagnosticCodes
 import io.eleven19.krueger.compiler.ParseDiagnostic
 import io.eleven19.krueger.lexer.{ElmTokenizer, ElmTokenizerConfig}
 
@@ -18,8 +19,11 @@ object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
                         diagnostic.message.startsWith("-- PARSE ERROR (ELM-P001)"),
                         diagnostic.message.contains("I ran into the end of the file unexpectedly."),
                         diagnostic.message.contains("I was expecting one of the following:"),
+                        diagnostic.message.contains("1| module M exposing (..)"),
                         diagnostic.message.contains("3| x ="),
-                        diagnostic.message.linesIterator.toList.last == "      ^"
+                        diagnostic.message.linesIterator.toList.last == "      ^",
+                        diagnostic.contextLines.nonEmpty,
+                        diagnostic.contextLines.count(_.isErrorLine) == 1
                     )
                 case Success(_) => assertTrue(false)
         },
@@ -31,7 +35,8 @@ object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
                         diagnostic.message.startsWith("-- TOKENIZE ERROR (ELM-T001)") &&
                         diagnostic.message.contains("I ran into an unexpected character:") &&
                         diagnostic.message.contains("1| main @") &&
-                        diagnostic.message.linesIterator.toList.last == "        ^"
+                        diagnostic.message.linesIterator.toList.last == "        ^" &&
+                        diagnostic.contextLines.count(_.isErrorLine) == 1
                     case _ => false
                 }
             )

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
@@ -4,8 +4,7 @@ import parsley.{Failure, Success}
 import zio.test.*
 
 import io.eleven19.krueger.Krueger
-import io.eleven19.krueger.compiler.DiagnosticCodes
-import io.eleven19.krueger.compiler.ParseDiagnostic
+import io.eleven19.krueger.compiler.{DiagnosticCode, ParseDiagnostic}
 import io.eleven19.krueger.lexer.{ElmTokenizer, ElmTokenizerConfig}
 
 object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
@@ -16,6 +15,7 @@ object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
             Krueger.parseCst(source) match
                 case Failure(diagnostic: ParseDiagnostic) =>
                     assertTrue(
+                        diagnostic.code == DiagnosticCode.UnexpectedEndOfInput,
                         diagnostic.message.startsWith("-- PARSE ERROR (ELM-P001)"),
                         diagnostic.message.contains("I ran into the end of the file unexpectedly."),
                         diagnostic.message.contains("I was expecting one of the following:"),
@@ -32,6 +32,7 @@ object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
             assertTrue(
                 result.errors.exists {
                     case io.eleven19.krueger.compiler.CompileError.ParseError("tokenize", diagnostic) =>
+                        diagnostic.code == DiagnosticCode.TokenizerUnexpectedCharacter &&
                         diagnostic.message.startsWith("-- TOKENIZE ERROR (ELM-T001)") &&
                         diagnostic.message.contains("I ran into an unexpected character:") &&
                         diagnostic.message.contains("1| main @") &&

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticMessageSnapshotSpec.scala
@@ -1,0 +1,39 @@
+package io.eleven19.krueger.parser
+
+import parsley.{Failure, Success}
+import zio.test.*
+
+import io.eleven19.krueger.Krueger
+import io.eleven19.krueger.compiler.ParseDiagnostic
+import io.eleven19.krueger.lexer.{ElmTokenizer, ElmTokenizerConfig}
+
+object ParseDiagnosticMessageSnapshotSpec extends ZIOSpecDefault:
+
+    def spec = suite("ParseDiagnosticMessageSnapshot")(
+        test("malformed module value documents the friendly end-of-input message shape") {
+            val source = "module M exposing (..)\n\nx ="
+            Krueger.parseCst(source) match
+                case Failure(diagnostic: ParseDiagnostic) =>
+                    assertTrue(
+                        diagnostic.message.startsWith("-- PARSE ERROR (ELM-P001)"),
+                        diagnostic.message.contains("I ran into the end of the file unexpectedly."),
+                        diagnostic.message.contains("I was expecting one of the following:"),
+                        diagnostic.message.contains("3| x ="),
+                        diagnostic.message.linesIterator.toList.last == "      ^"
+                    )
+                case Success(_) => assertTrue(false)
+        },
+        test("tokenizer failure documents the friendly unexpected-character message shape") {
+            val result = ElmTokenizer.run("main @", ElmTokenizerConfig(includeTrivia = false, recoverUnknown = false))
+            assertTrue(
+                result.errors.exists {
+                    case io.eleven19.krueger.compiler.CompileError.ParseError("tokenize", diagnostic) =>
+                        diagnostic.message.startsWith("-- TOKENIZE ERROR (ELM-T001)") &&
+                        diagnostic.message.contains("I ran into an unexpected character:") &&
+                        diagnostic.message.contains("1| main @") &&
+                        diagnostic.message.linesIterator.toList.last == "        ^"
+                    case _ => false
+                }
+            )
+        }
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
@@ -4,7 +4,7 @@ import parsley.{Failure, Success}
 import zio.test.*
 
 import io.eleven19.krueger.Krueger
-import io.eleven19.krueger.compiler.DiagnosticCodes
+import io.eleven19.krueger.compiler.DiagnosticCode
 import io.eleven19.krueger.compiler.ParseDiagnostic
 
 object ParseDiagnosticParserSpec extends ZIOSpecDefault:
@@ -22,7 +22,7 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
             Krueger.parseCst(malformedSource) match
                 case Failure(diagnostic: ParseDiagnostic) =>
                     assertTrue(
-                        diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                        diagnostic.code == DiagnosticCode.UnexpectedEndOfInput,
                         diagnostic.span.line == 3,
                         diagnostic.span.column == 4,
                         diagnostic.span.start == 27,
@@ -42,7 +42,7 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
             Krueger.parseCst("") match
                 case Failure(diagnostic: ParseDiagnostic) =>
                     assertTrue(
-                        diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                        diagnostic.code == DiagnosticCode.UnexpectedEndOfInput,
                         diagnostic.span.line == 1,
                         diagnostic.span.column == 1,
                         diagnostic.span.start == 0,

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
@@ -29,9 +29,12 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.span.end == 27,
                         diagnostic.expected.nonEmpty,
                         diagnostic.message.contains("I ran into the end of the file unexpectedly"),
+                        diagnostic.message.contains("1| module M exposing (..)"),
                         diagnostic.message.contains("3| x ="),
                         diagnostic.message.contains("^"),
-                        diagnostic.message.contains("I was expecting one of the following:")
+                        diagnostic.message.contains("I was expecting one of the following:"),
+                        diagnostic.contextLines.nonEmpty,
+                        diagnostic.contextLines.count(_.isErrorLine) == 1
                     )
                 case Success(_) => assertTrue(false)
         },
@@ -48,7 +51,8 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.message.contains("I ran into the end of the file unexpectedly"),
                         diagnostic.message.contains("1|"),
                         diagnostic.message.contains("^"),
-                        diagnostic.message.contains("I was expecting one of the following:")
+                        diagnostic.message.contains("I was expecting one of the following:"),
+                        diagnostic.contextLines.nonEmpty
                     )
                 case Success(_) => assertTrue(false)
         }

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
@@ -28,9 +28,10 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.span.start == 27,
                         diagnostic.span.end == 27,
                         diagnostic.expected.nonEmpty,
-                        diagnostic.message.contains("unexpected end of input"),
-                        diagnostic.message.contains(">x ="),
-                        diagnostic.message.contains("^")
+                        diagnostic.message.contains("I ran into the end of the file unexpectedly"),
+                        diagnostic.message.contains("3| x ="),
+                        diagnostic.message.contains("^"),
+                        diagnostic.message.contains("I was expecting one of the following:")
                     )
                 case Success(_) => assertTrue(false)
         },
@@ -44,9 +45,10 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.span.start == 0,
                         diagnostic.span.end == 0,
                         diagnostic.expected.contains("module"),
-                        diagnostic.message.contains("unexpected end of input"),
-                        diagnostic.message.contains(">"),
-                        diagnostic.message.contains("^")
+                        diagnostic.message.contains("I ran into the end of the file unexpectedly"),
+                        diagnostic.message.contains("1|"),
+                        diagnostic.message.contains("^"),
+                        diagnostic.message.contains("I was expecting one of the following:")
                     )
                 case Success(_) => assertTrue(false)
         }

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
@@ -1,0 +1,48 @@
+package io.eleven19.krueger.parser
+
+import parsley.{Failure, Success}
+import zio.test.*
+
+import io.eleven19.krueger.Krueger
+import io.eleven19.krueger.compiler.DiagnosticCodes
+import io.eleven19.krueger.compiler.ParseDiagnostic
+
+object ParseDiagnosticParserSpec extends ZIOSpecDefault:
+
+    private val malformedSource = "module M exposing (..)\n\nx ="
+
+    def spec = suite("ParseDiagnosticParser")(
+        test("happy path: valid source produces zero diagnostics") {
+            val source = "module M exposing (..)\n\nx = 1\n"
+            Krueger.parseCst(source) match
+                case Success(_) => assertTrue(true)
+                case Failure(_) => assertTrue(false)
+        },
+        test("malformed source produces ELM-P001 with span and expected tokens") {
+            Krueger.parseCst(malformedSource) match
+                case Failure(diagnostic: ParseDiagnostic) =>
+                    assertTrue(
+                        diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                        diagnostic.span.line == 3,
+                        diagnostic.span.column == 4,
+                        diagnostic.span.start == 27,
+                        diagnostic.span.end == 27,
+                        diagnostic.expected.nonEmpty,
+                        diagnostic.message.contains("unexpected end of input")
+                    )
+                case Success(_) => assertTrue(false)
+        },
+        test("empty source produces ELM-P001 at start of file") {
+            Krueger.parseCst("") match
+                case Failure(diagnostic: ParseDiagnostic) =>
+                    assertTrue(
+                        diagnostic.code == DiagnosticCodes.UnexpectedEndOfInput,
+                        diagnostic.span.line == 1,
+                        diagnostic.span.column == 1,
+                        diagnostic.span.start == 0,
+                        diagnostic.span.end == 0,
+                        diagnostic.expected.contains("module")
+                    )
+                case Success(_) => assertTrue(false)
+        }
+    )

--- a/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
+++ b/krueger/core/test/src/io/eleven19/krueger/parser/ParseDiagnosticParserSpec.scala
@@ -28,7 +28,9 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.span.start == 27,
                         diagnostic.span.end == 27,
                         diagnostic.expected.nonEmpty,
-                        diagnostic.message.contains("unexpected end of input")
+                        diagnostic.message.contains("unexpected end of input"),
+                        diagnostic.message.contains(">x ="),
+                        diagnostic.message.contains("^")
                     )
                 case Success(_) => assertTrue(false)
         },
@@ -41,7 +43,10 @@ object ParseDiagnosticParserSpec extends ZIOSpecDefault:
                         diagnostic.span.column == 1,
                         diagnostic.span.start == 0,
                         diagnostic.span.end == 0,
-                        diagnostic.expected.contains("module")
+                        diagnostic.expected.contains("module"),
+                        diagnostic.message.contains("unexpected end of input"),
+                        diagnostic.message.contains(">"),
+                        diagnostic.message.contains("^")
                     )
                 case Success(_) => assertTrue(false)
         }

--- a/krueger/itest/resources/features/compiler-api.feature
+++ b/krueger/itest/resources/features/compiler-api.feature
@@ -36,7 +36,7 @@ Feature: Compiler API backends
     Then the compiler response is not ok
     And the compiler response has at least 1 error
     And compiler error 1 phase is "cst"
-    And compiler error 1 message contains "unexpected end of input"
+    And compiler error 1 message contains "I ran into the end of the file unexpectedly"
 
     Examples:
       | backend |

--- a/krueger/itest/src/io/eleven19/krueger/itest/TestDriver.scala
+++ b/krueger/itest/src/io/eleven19/krueger/itest/TestDriver.scala
@@ -12,6 +12,7 @@ import io.eleven19.krueger.Krueger
 import io.eleven19.krueger.ast.AstNode
 import io.eleven19.krueger.ast.AstQueryableTree.given
 import io.eleven19.krueger.ast.Module
+import io.eleven19.krueger.compiler.ParseDiagnostic
 import io.eleven19.krueger.compiler.abi.InvokeCompiler
 import io.eleven19.krueger.cst.CstModule
 import io.eleven19.krueger.cst.CstNode
@@ -119,8 +120,8 @@ object TestDriver:
 /** Scenario-scoped mutable state shared across step-definition classes via the cucumber-scala DI container. */
 final class TestDriver:
     private var source: String                               = ""
-    private var cstResult: Option[Result[String, CstModule]] = None
-    private var astResult: Option[Result[String, Module]]    = None
+    private var cstResult: Option[Result[ParseDiagnostic, CstModule]] = None
+    private var astResult: Option[Result[ParseDiagnostic, Module]]    = None
     private var lastMatchesBuf: Vector[MatchView]            = Vector.empty
     private var querySource: Option[String]                  = None
     private var canonicalQueryText: Option[String]           = None
@@ -146,12 +147,14 @@ final class TestDriver:
 
     def cst: CstModule = cstResult match
         case Some(Success(m))   => m
-        case Some(Failure(msg)) => throw new AssertionError(s"CST parse failed: $msg\nSource:\n$source")
+        case Some(Failure(diagnostic: ParseDiagnostic)) =>
+            throw new AssertionError(s"CST parse failed: ${diagnostic.message}\nSource:\n$source")
         case None               => throw new AssertionError("CST not parsed — missing When step?")
 
     def ast: Module = astResult match
         case Some(Success(m))   => m
-        case Some(Failure(msg)) => throw new AssertionError(s"AST parse failed: $msg\nSource:\n$source")
+        case Some(Failure(diagnostic: ParseDiagnostic)) =>
+            throw new AssertionError(s"AST parse failed: ${diagnostic.message}\nSource:\n$source")
         case None               => throw new AssertionError("AST not parsed — missing When step?")
 
     /** Parse the CST (if not already parsed), run `queryText` against it, and store the matches. */

--- a/krueger/itest/src/io/eleven19/krueger/itest/TestDriver.scala
+++ b/krueger/itest/src/io/eleven19/krueger/itest/TestDriver.scala
@@ -119,12 +119,12 @@ object TestDriver:
 
 /** Scenario-scoped mutable state shared across step-definition classes via the cucumber-scala DI container. */
 final class TestDriver:
-    private var source: String                               = ""
+    private var source: String                                        = ""
     private var cstResult: Option[Result[ParseDiagnostic, CstModule]] = None
     private var astResult: Option[Result[ParseDiagnostic, Module]]    = None
-    private var lastMatchesBuf: Vector[MatchView]            = Vector.empty
-    private var querySource: Option[String]                  = None
-    private var canonicalQueryText: Option[String]           = None
+    private var lastMatchesBuf: Vector[MatchView]                     = Vector.empty
+    private var querySource: Option[String]                           = None
+    private var canonicalQueryText: Option[String]                    = None
 
     def setSource(raw: String): Unit =
         source = raw
@@ -146,16 +146,16 @@ final class TestDriver:
     def parseAst(): Unit = astResult = Some(Krueger.parseAst(source))
 
     def cst: CstModule = cstResult match
-        case Some(Success(m))   => m
+        case Some(Success(m)) => m
         case Some(Failure(diagnostic: ParseDiagnostic)) =>
             throw new AssertionError(s"CST parse failed: ${diagnostic.message}\nSource:\n$source")
-        case None               => throw new AssertionError("CST not parsed — missing When step?")
+        case None => throw new AssertionError("CST not parsed — missing When step?")
 
     def ast: Module = astResult match
-        case Some(Success(m))   => m
+        case Some(Success(m)) => m
         case Some(Failure(diagnostic: ParseDiagnostic)) =>
             throw new AssertionError(s"AST parse failed: ${diagnostic.message}\nSource:\n$source")
-        case None               => throw new AssertionError("AST not parsed — missing When step?")
+        case None => throw new AssertionError("AST not parsed — missing When step?")
 
     /** Parse the CST (if not already parsed), run `queryText` against it, and store the matches. */
     def queryCst(queryText: String): Unit =

--- a/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
+++ b/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
@@ -166,9 +166,17 @@ object KruegerJs:
     private def errorPojo(e: CompileError): js.Object =
         import CompileError.*
         e match
-            case ParseError(phase, message, spanOpt) =>
-                val o = js.Dynamic.literal(phase = phase, message = message)
-                spanOpt.foreach(s => o.updateDynamic("span")(spanPojo(s)))
+            case ParseError(phase, diagnostic) =>
+                val o = js.Dynamic.literal(
+                    phase = phase,
+                    message = diagnostic.message,
+                    code = diagnostic.code,
+                    expected = diagnostic.expected.toJSArray,
+                    span = spanPojo(diagnostic.toCompilerSpan),
+                    line = diagnostic.span.line,
+                    column = diagnostic.span.column
+                )
+                diagnostic.suggestion.foreach(s => o.updateDynamic("suggestion")(s))
                 o.asInstanceOf[js.Object]
             case QueryError(message, spanOpt) =>
                 val o = js.Dynamic.literal(phase = "query", message = message)

--- a/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
+++ b/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
@@ -167,6 +167,13 @@ object KruegerJs:
         import CompileError.*
         e match
             case ParseError(phase, diagnostic) =>
+                val contextLines = diagnostic.contextLines.map { line =>
+                    js.Dynamic.literal(
+                        line = line.line,
+                        text = line.text,
+                        isErrorLine = line.isErrorLine
+                    )
+                }.toJSArray
                 val o = js.Dynamic.literal(
                     phase = phase,
                     message = diagnostic.message,
@@ -174,7 +181,8 @@ object KruegerJs:
                     expected = diagnostic.expected.toJSArray,
                     span = spanPojo(diagnostic.toCompilerSpan),
                     line = diagnostic.span.line,
-                    column = diagnostic.span.column
+                    column = diagnostic.span.column,
+                    contextLines = contextLines
                 )
                 diagnostic.suggestion.foreach(s => o.updateDynamic("suggestion")(s))
                 o.asInstanceOf[js.Object]

--- a/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
+++ b/krueger/webapp-wasm/src/io/eleven19/krueger/webappwasm/KruegerJs.scala
@@ -10,6 +10,7 @@ import io.eleven19.krueger.ast.AstUnistProjection.given
 import io.eleven19.krueger.compiler.CapturedNode
 import io.eleven19.krueger.compiler.CompileError
 import io.eleven19.krueger.compiler.CompilerComponent
+import io.eleven19.krueger.compiler.DiagnosticCode
 import io.eleven19.krueger.compiler.MatchView
 import io.eleven19.krueger.compiler.Span
 import io.eleven19.krueger.cst.CstModule
@@ -177,7 +178,7 @@ object KruegerJs:
                 val o = js.Dynamic.literal(
                     phase = phase,
                     message = diagnostic.message,
-                    code = diagnostic.code,
+                    code = DiagnosticCode.unwrap(diagnostic.code),
                     expected = diagnostic.expected.toJSArray,
                     span = spanPojo(diagnostic.toCompilerSpan),
                     line = diagnostic.span.line,

--- a/krueger/webapp-wasm/test/src/io/eleven19/krueger/webappwasm/CompilerApiAcceptanceCases.scala
+++ b/krueger/webapp-wasm/test/src/io/eleven19/krueger/webappwasm/CompilerApiAcceptanceCases.scala
@@ -23,5 +23,5 @@ object CompilerApiAcceptanceCases:
         MalformedParseCst(
             source = "module Demo exposing (..)\n\nmain =\n",
             expectedPhase = "cst",
-            expectedMessageFragment = "unexpected end of input"
+            expectedMessageFragment = "I ran into the end of the file unexpectedly"
         )

--- a/krueger/webapp-wasm/test/src/io/eleven19/krueger/webappwasm/KruegerJsSpec.scala
+++ b/krueger/webapp-wasm/test/src/io/eleven19/krueger/webappwasm/KruegerJsSpec.scala
@@ -241,6 +241,8 @@ object KruegerJsSpec extends ZIOSpecDefault:
             test("malformed parseCst source matches the JVM and Chicory error scenario") {
                 val env    = dyn(KruegerJs.parseCst(CompilerApiAcceptanceCases.malformedParseCst.source))
                 val errors = env.errors.asInstanceOf[js.Array[js.Dynamic]]
+                val error  = errors(0)
+                val contextLines = error.contextLines.asInstanceOf[js.Array[js.Dynamic]]
                 assertTrue(
                     hasEnvelopeShape(env.asInstanceOf[js.Object]),
                     !env.ok.asInstanceOf[Boolean],
@@ -248,6 +250,10 @@ object KruegerJsSpec extends ZIOSpecDefault:
                     errors(0).phase.asInstanceOf[String] == CompilerApiAcceptanceCases.malformedParseCst.expectedPhase,
                     errors(0).message.asInstanceOf[String].contains(
                         CompilerApiAcceptanceCases.malformedParseCst.expectedMessageFragment
+                    ),
+                    contextLines.length >= 1,
+                    (0 until contextLines.length).exists(index =>
+                        contextLines(index).isErrorLine.asInstanceOf[Boolean]
                     )
                 )
             },

--- a/sites/try-wasm/src/lib/components/activity-results.test.ts
+++ b/sites/try-wasm/src/lib/components/activity-results.test.ts
@@ -191,14 +191,14 @@ describe('try-wasm ActivityBar and ResultsPanel components', () => {
       ResultsPanel,
       resultProps({
         selectedPanel: 'cst',
-        cstResult: error('unexpected end of input'),
-        cstUnistResult: error('unexpected end of input')
+        cstResult: error('I ran into the end of the file unexpectedly.'),
+        cstUnistResult: error('I ran into the end of the file unexpectedly.')
       })
     );
 
     expect(screen.getByRole('tabpanel', { name: 'CST' })).not.toBeNull();
     expect(screen.getByText('Parse errors:')).not.toBeNull();
-    expect(screen.getByText('unexpected end of input')).not.toBeNull();
+    expect(screen.getByText('I ran into the end of the file unexpectedly.')).not.toBeNull();
   });
 
   it('renders the canonical query echo panel', () => {

--- a/sites/try-wasm/src/lib/krueger.test.ts
+++ b/sites/try-wasm/src/lib/krueger.test.ts
@@ -106,7 +106,7 @@ describe('krueger.ts real compiler facade wrapper', () => {
     expect(cst.value).toBeNull();
     expect(cst.errors.length).toBeGreaterThan(0);
     expect(cst.errors[0]?.phase).toBe('cst');
-    expect(cst.errors[0]?.message).toContain('unexpected end of input');
+    expect(cst.errors[0]?.message).toContain('I ran into the end of the file unexpectedly.');
   });
 
   it('returns existing error envelopes for malformed CST and AST unist parses', async () => {
@@ -122,7 +122,7 @@ describe('krueger.ts real compiler facade wrapper', () => {
     expect(ast.value).toBeNull();
     expect(cst.errors[0]?.phase).toBe('cst');
     expect(ast.errors[0]?.phase).toBe('ast');
-    expect(ast.errors[0]?.message).toContain('unexpected end of input');
+    expect(ast.errors[0]?.message).toContain('I ran into the end of the file unexpectedly.');
   });
 
   it('supports stale facades without unist methods while degrading unist calls to internal error envelopes', async () => {


### PR DESCRIPTION
## Summary

Implements **E-6.5 / krueger-cnh**: upgrades Elm parse failures from opaque Parsley strings to structured `ParseDiagnostic` values with stable codes, source spans, expected token sets, optional suggestions, **Elm-inspired human-friendly messages**, and **surrounding source context** (2 lines before + 1 line after the error line).

Diagnostics flow through the core parser, `CompileError`, compiler-api envelope, JSON `invoke` ABI, and `KruegerJs` browser facade.

Closes the diagnostics foundation needed before **E-6.6** (multi-error recovery + partial CST).

## Motivation

Prior parse errors were minimal — a phase label and a raw Parsley string. That made it hard to:

- Render precise squigglies in a language server or playground
- Write regression tests against specific failure kinds
- Surface expected tokens or actionable hints to users
- Show surrounding source lines for quick orientation

This PR introduces a single structured diagnostic type, threads it end-to-end, and formats `message` the way Elm and modern compilers do: header → plain-English explanation → expected alternatives → multi-line numbered source snippet with caret → optional hint.

## Stable diagnostic codes

| Code | Meaning |
|------|---------|
| `ELM-P001` | Unexpected end of input |
| `ELM-P002` | Unexpected token |
| `ELM-P003` | Specialised Parsley parse failure |
| `ELM-T001` | Tokenizer unexpected character |

Codes are immutable once assigned; semantic changes require a new code, not a rename.

## Core data model

```scala
final case class DiagnosticContextLine(
    line: Int,
    text: String,
    isErrorLine: Boolean
)

final case class ParseDiagnostic(
    code: String,
    span: SourceSpan,          // start/end offsets + line/column
    message: String,           // friendly, Elm-style formatted text
    expected: List[String],
    suggestion: Option[String] = None,
    contextLines: List[DiagnosticContextLine] = Nil
)
```

`message` is formatted by `DiagnosticMessageFormatter` via `SourceSnippetBuilder` (2 before, 1 after). Structured fields (`code`, `span`, `expected`, `suggestion`, `contextLines`) remain available for UIs that want to render their own chrome.

## Example messages (full `message` field)

### 1) Unexpected end of input after incomplete expression

Source:

```elm
module M exposing (..)

x =
```

`message`:

```text
-- PARSE ERROR (ELM-P001) at line 3, column 4

I ran into the end of the file unexpectedly.

I was expecting one of the following:

    identifier
    digit
    ...

1| module M exposing (..)
2| 
3| x =
      ^
```

Structured: `contextLines` = lines 1–3 with `isErrorLine=true` on line 3.

### 2) Incomplete `main` binding (playground / browser parity case)

Source:

```elm
module Demo exposing (..)

main =

```

`message`:

```text
-- PARSE ERROR (ELM-P001) at line 3, column 7

I ran into the end of the file unexpectedly.

I was expecting one of the following:

    ...

1| module Demo exposing (..)
2| 
3| main =
         ^
4| 
```

### 3) Empty file

Source: `` (empty)

`message`:

```text
-- PARSE ERROR (ELM-P001) at line 1, column 1

I ran into the end of the file unexpectedly.

I was expecting one of the following:

    effect
    module
    port

1|
  ^
```

### 4) Tokenizer unexpected character

Source: `main @`

`message`:

```text
-- TOKENIZE ERROR (ELM-T001) at line 1, column 6

I ran into an unexpected character:

    @

1| main @
        ^
```

### 5) Optional hint (missing `in` after `let`)

When EOF meets an expected `in` token, `suggestion` is populated and appended:

```text
Hint: Did you forget `in` after a `let` binding?
```

## ABI + browser facade

`InvokeError` / `KruegerJs` error POJOs expose `code`, `expected`, `suggestion`, `line`, `column`, and `contextLines` (array of `{ line, text, isErrorLine }`) in addition to `phase`, `message`, and `span`. Docs: [`docs/src/content/docs/tooling.md`](docs/src/content/docs/tooling.md)

## Commits

1. **`feat(diagnostics): add structured ParseDiagnostic with stable codes (E-6.5)`** — core implementation
2. **`fix(diagnostics): restore parse error contracts`** — explicit `ParseDiagnostic` pattern types + real source lines in snippets
3. **`fix(diagnostics): Elm-style friendly messages and itest compile fix`** — `DiagnosticMessageFormatter`, itest `TestDriver` fix, updated acceptance/BDD checks
4. **`feat(diagnostics): add surrounding source context and contextLines ABI`** — `SourceSnippetBuilder`, multi-line snippets, ABI/browser `contextLines`, CI parity fixes

## Test coverage

| Area | Tests |
|------|-------|
| Snippet builder | `SourceSnippetBuilderSpec` (clamping, trailing newline) |
| Formatter goldens | `DiagnosticMessageFormatterSpec` |
| Message shape snapshots | `ParseDiagnosticMessageSnapshotSpec` |
| Parser integration | `ParseDiagnosticParserSpec` |
| Tokenizer | `ElmTokenizerSpec` (`ELM-T001`) |
| Compiler envelope | `CompilerComponentSpec` |
| JSON invoke ABI | `InvokeCompilerSpec` (`contextLines`) |
| Browser facade | `KruegerJsSpec` (`contextLines`) |
| BDD backends | `compiler-api.feature` (JVM / Chicory / Scala.js Node) |
| Browser parity script | `check-webapp-wasm-browser.mjs` |

Cross-platform: JVM, Scala.js, and Scala Native suites pass locally.

## EARS requirements addressed

- **REQ-E65-001** — `SourceSpan` (offsets + line/column)
- **REQ-E65-002** — `expected` token list from Parsley failure sets
- **REQ-E65-003** — optional `suggestion` for recognized patterns
- **REQ-E65-004** — stable alphanumeric codes on all current parse/tokenizer error sites

## Out of scope (follow-ups)

- **E-6.6** — multi-error recovery and partial CST
- Query parser diagnostics still use string normalization
- Playground UI rendering of `contextLines` (ABI field lands first; UI can follow)
- Configurable per-call context depth (fixed defaults: 2 before, 1 after)

## Test plan

- [x] `./mill krueger.core.jvm.test`
- [x] `./mill krueger.compiler-api.jvm.test`
- [x] `./mill krueger.itest`
- [x] `./mill krueger.core.js.test krueger.compiler-api.js.test`
- [x] `./mill krueger.core.native.test`
- [x] `./mill krueger.webapp-wasm.js.test`
- [x] `./mill krueger.core.jvm.checkFormat krueger.itest.checkFormat`
- [x] `./mill krueger.webapp-wasm.fullLinkJS` (prerequisite for browser parity)
- [ ] `npm --prefix docs run test:webapp-wasm-browser` (requires `playwright` in docs deps)
- [ ] Manual: parse malformed Elm in playground; confirm friendly `message` + structured `code` / `expected` / `line` / `column` / `contextLines`